### PR TITLE
Regex import error fix: import re instead of import regex as re

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-import regex as re
+import re
 import socket
 import subprocess
 import sys


### PR DESCRIPTION
Running the script throws this error:
Traceback (most recent call last):
  File "/home/leon/code/ebook2audiobook/app.py", line 3, in <module>
    import regex as re
ModuleNotFoundError: No module named 'regex'

This PR fixes this error by setting the import to `import re` instead of `import regex as re`

Fixes #135