### PR TITLE
missing regex in requirements added

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ mecab-python3
 pydub
 pypinyin
 ray
+regex
 transformers
 translate
 tqdm


### PR DESCRIPTION
Running the script throws this error:
Traceback (most recent call last):
File "/home/leon/code/ebook2audiobook/app.py", line 3, in
import regex as re
ModuleNotFoundError: No module named 'regex'

This PR adds regex to the requirements.txt

Fixes #135