### PR TITLE
Kaggel Archive Code: Uncomment missing imports

### DIFF
--- a/Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py
+++ b/Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py
@@ -1,11 +1,11 @@
 print("starting...")
 
 #import os
-#import shutil
+import shutil
 #import subprocess
 import re
 #from pydub import AudioSegment
-#import tempfile
+import tempfile
 #from pydub import AudioSegment
 #import os
 import nltk

--- a/Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py
+++ b/Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py
@@ -149,11 +149,11 @@ def create_m4b_from_chapters(input_dir, ebook_file, output_dir):
 #this code right here isnt the book grabbing thing but its before to refrence in ordero to create the sepecial chapter labeled book thing with calibre idk some systems cant seem to get it so just in case but the next bit of code after this is the book grabbing code with booknlp 
 #import os
 #import subprocess
-#import ebooklib
-#from ebooklib import epub
-#from bs4 import BeautifulSoup
+import ebooklib
+from ebooklib import epub
+from bs4 import BeautifulSoup
 #import re
-#import csv
+import csv
 #import nltk
 
 # Only run the main script if Value is True

--- a/Notebooks/Kaggel Archive Code/p2a_worker_gpu2.py
+++ b/Notebooks/Kaggel Archive Code/p2a_worker_gpu2.py
@@ -1,11 +1,11 @@
 print("starting...")
 
 #import os
-#import shutil
+import shutil
 #import subprocess
 import re
 #from pydub import AudioSegment
-#import tempfile
+import tempfile
 #from pydub import AudioSegment
 #import os
 import nltk


### PR DESCRIPTION
% `ruff check --output-format=concise` # https://docs.astral.sh/ruff/linter
```
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:27:9: F821 Undefined name `shutil`
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:50:13: F821 Undefined name `shutil`
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:123:16: F821 Undefined name `tempfile`
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:184:16: F821 Undefined name `epub`
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:192:35: F821 Undefined name `ebooklib`
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:194:24: F821 Undefined name `BeautifulSoup`
Notebooks/Kaggel Archive Code/p2a_worker_gpu1.py:230:22: F821 Undefined name `csv`
Notebooks/Kaggel Archive Code/p2a_worker_gpu2.py:27:9: F821 Undefined name `shutil`
Notebooks/Kaggel Archive Code/p2a_worker_gpu2.py:50:13: F821 Undefined name `shutil`
Notebooks/Kaggel Archive Code/p2a_worker_gpu2.py:123:16: F821 Undefined name `tempfile`
```