### PR TITLE
Update README.md to add dependency install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,19 @@ git clone https://github.com/DrewThomasson/ebook2audiobook.git
 
 Specify the language code when running the script in  mode.
 
-
 ### Launching Gradio Web Interface
-
-1. **Run ebook2audiobook**:
+1. **Install dependencies**
+   - **Linux**:
+     ```bash
+      sudo apt-get update && sudo apt-get -y upgrade
+      sudo apt-get -y install libegl1 libopengl0 libxcb-cursor0 ffmpeg mecab libmecab-dev mecab-ipadic-utf8
+      ```
+2. **Install calibre if needed**
+    - **Linux**
+      ```bash
+      sudo -v && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin
+      ```
+3. **Run ebook2audiobook**:
    - **Linux/MacOS**:
      ```bash
      ./ebook2audiobook.sh  # Run Launch script


### PR DESCRIPTION
When trying to run this app on Zorin OS 17.2 core, I found that `mecab` failed to install due to a missing mecab install. I resolved it by installing mecab. To prevent this issue from happening to other people, I took the commands from colab and condensed them down so I could add them to README.md. Feel free to move the dependency install instructions around if you find they don't quite fit into the location I put them in (Running Gradio Web Interface).