### PR TITLE
Update ebook2audiobook.sh

### DIFF
--- a/ebook2audiobook.sh
+++ b/ebook2audiobook.sh
@@ -48,7 +48,7 @@ if [[ "$OSTYPE" != "linux"* && "$OSTYPE" != "darwin"* ]]; then
 	exit 1;
 fi
 
-ARCH=$(arch)
+ARCH=$(uname -m)
 
 if [[ "$OSTYPE" == "linux"* ]]; then
 	if [[ "$ARCH" == "x86_64" ]]; then


### PR DESCRIPTION
The original outputted this error 

[house@archlinux ebook2audiobook]$ ./ebook2audiobook.sh  ./ebook2audiobook.sh: line 51: arch: command not found Error: Unsupported architecture for Linux: .
