### PR TITLE
fix `Caught DependencyError: Error extracting main content pages: '/'`

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -383,7 +383,12 @@ def maths_to_words(text, lang, lang_iso1, tts_engine):
     )
     def replace_ambiguous(match):
         if match.group(2):  # "num SYMBOL num" case
-            return f"{match.group(1)} {ambiguous_replacements[match.group(2)]} {match.group(3)}"
+            matched = match.group(2)
+
+            if matched == "/":
+                matched = "-"
+
+            return f"{match.group(1)} {ambiguous_replacements[matched]} {match.group(3)}"
         elif match.group(3):  # "SYMBOL num" case
             return f"{ambiguous_replacements[match.group(3)]} {match.group(4)}"
         return match.group(0)


### PR DESCRIPTION
```
/home/bader/.local/lib/python3.12/site-packages/ebooklib/epub.py:1423: FutureWarning: This search incorrectly ignores the root element, and will be fixed in a future version.  If you rely on the current behaviour, change it to './/xmlns:rootfile[@media-type]'
  for root_file in tree.findall('//xmlns:rootfile[@media-type]', namespaces={'xmlns': NAMESPACES['CONTAINERNS']}):
******* NOTE: YOU CAN SAFELY IGNORE "Character xx not found in the vocabulary." *******
Error extracting main content pages: '/'
Traceback (most recent call last):
  File "/home/bader/ebook2audiobook/lib/functions.py", line 497, in get_chapters
    doc_cache[doc] = filter_chapter(doc, session['language'], session['language_iso1'], session['tts_engine'])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bader/ebook2audiobook/lib/functions.py", line 539, in filter_chapter
    text = normalize_text(text, lang, lang_iso1, tts_engine)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bader/ebook2audiobook/lib/functions.py", line 424, in normalize_text
    text = maths_to_words(text, lang, lang_iso1, tts_engine)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bader/ebook2audiobook/lib/functions.py", line 391, in maths_to_words
    text = re.sub(ambiguous_pattern, replace_ambiguous, text)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bader/.local/lib/python3.12/site-packages/regex/regex.py", line 278, in sub
    return pat.sub(repl, string, count, pos, endpos, concurrent, timeout)
           
  File "/home/bader/ebook2audiobook/lib/functions.py", line 386, in replace_ambiguous
    return f"{match.group(1)} {ambiguous_replacements[match.group(2)]} {match.group(3)}"
                               ^^^^^^^^^^^^^^^^
KeyError: '/'
Caught DependencyError: Error extracting main content pages: '/'
get_chapters() failed!
```

the issue was `/` wasn't found in the chapter so I was debuging and I did small fix by changing it to `-`