### PR TITLE
Add docker.io to the image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-gpu-disabled: &gpu-disabled
 
 services:
   ebook2audiobook:
-    image: athomasson2/ebook2audiobook:latest
+    image: docker.io/athomasson2/ebook2audiobook:latest
     platform: linux/amd64
     tty: true
     stdin_open: true


### PR DESCRIPTION
In podman and other we don't by default request docker.io so lets add