### PR TITLE
Fixed to run with the simple `act` command locally

### DIFF
--- a/.github/workflows/run-ubuntu-headless-ebook2audiobook.yml
+++ b/.github/workflows/run-ubuntu-headless-ebook2audiobook.yml
@@ -1,6 +1,9 @@
 name: Run Ubuntu Headless ebook2audiobook 
 
 on:
+  push:
+    branches:
+      - act-trigger
   workflow_dispatch:
 
 


### PR DESCRIPTION
Now activates on a push to a branch name that will never exist

Allowing me to run it with the simple `act` command for local testing

Instead of having to specify to act to test this workflow in particular