### PR TITLE
switched to absolute path for TMPDIR

### DIFF
--- a/ebook2audiobook.sh
+++ b/ebook2audiobook.sh
@@ -46,7 +46,8 @@ FULL_DOCKER="full_docker"
 SCRIPT_MODE="$NATIVE"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-TMPDIR=./.cache
+export TMPDIR="/tmp/ebook2audiobook_cache"
+mkdir -p "$TMPDIR"
 
 WGET=$(which wget 2>/dev/null)
 REQUIRED_PROGRAMS=("calibre" "ffmpeg" "nodejs" "mecab" "espeak-ng" "rust")


### PR DESCRIPTION
The relative path ./.cache was causing problems for the libmamba installer on my system for some reason. 

but it appears that using an absolute path for TMPDIR fixed the issue for me? 

🤷 

- switched to
```bash
export TMPDIR="/tmp/ebook2audiobook_cache"
mkdir -p "$TMPDIR"

```