### PR TITLE
Removed release trigger from Dev test

### DIFF
--- a/.github/workflows/dev-docker-test.yml
+++ b/.github/workflows/dev-docker-test.yml
@@ -2,9 +2,6 @@ name: Full Dev Docker Test
 
 on:
   workflow_dispatch: {}
-  release:
-    types:
-      - published
   push:
     branches:
       - v25
@@ -15,6 +12,7 @@ on:
       - readme/**
       - dockerfiles/**
       - Notebooks/**
+
 
 jobs:
   build:


### PR DESCRIPTION
Cause that's for the main Build+Test to do

This is redundancy for no reason if I have this also run lol