### PR TITLE
Fix IndexError in split_sentence when handling empty strings (frequent in Chinese EPUBs)

### DIFF
--- a/lib/functions.py
+++ b/lib/functions.py
@@ -649,6 +649,8 @@ def get_sentences(text, lang):
     def split_sentence(sentence):
         end = ''
         if len(sentence) <= max_chars:
+            if not sentence:
+                return []
             if sentence[-1].isalpha():
                 end = '–'
             return [sentence + end]


### PR DESCRIPTION
This PR fixes an IndexError in `split_sentence()` when the input sentence is an empty string. This issue occurs frequently in Chinese EPUB books due to how some chapters are structured or extracted.

Adding a simple `if not sentence: return []` guard avoids the crash without changing existing behavior.
