### PR TITLE
quick fix docker-build+test.yml

### DIFF
--- a/.github/workflows/docker-build+test.yml
+++ b/.github/workflows/docker-build+test.yml
@@ -270,7 +270,7 @@ jobs:
 
 
   final_push:
-    needs: run_tests
+    needs: build
     if: ${{ !failure() || inputs.require_all_tests == false }}
     runs-on: self-hosted
     env:
@@ -382,7 +382,7 @@ jobs:
 
   
   build_variants:
-      needs: run_tests
+      needs: build
       if: ${{ !failure() || inputs.require_all_tests == false }}
       runs-on: self-hosted
       strategy:
@@ -534,7 +534,7 @@ jobs:
 
 
   huggingface-build:
-    needs: run_tests
+    needs: build
     if: ${{ !failure() || inputs.require_all_tests == false }}
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
This is quick fix to make it always give the latest docker images the correct tag.

As sometimes it... does not

This is because it is allowed to push and build the varients even... if the base builds never build... which pushes the.. old cached version... with the new version tag...

Now it requires the base build to push as the latest and as the tag suchlike.

Which should fix this issue while I rebuild and streamline the workflows further..