### PR TITLE
Remove push main trigger for Docker Build workflow, not needed

### DIFF
--- a/.github/workflows/Docker-Build.yml
+++ b/.github/workflows/Docker-Build.yml
@@ -6,16 +6,6 @@ on:
       wipeAndReinstall:
         type: boolean
         description: 'Wipe & Re-Install E2A'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - CODE_OF_CONDUCT.md
-      - LICENSE
-      - README.md
-      - readme/**
-      - dockerfiles/**
-      - Notebooks/**
 
   workflow_run:
     workflows: ["Mac E2A Test"]


### PR DESCRIPTION
+ it made trigger twice as its already triggered by E2A Test running on main anyway