### PR TITLE
Improve TTS text preprocessing to prevent audio artifacts

### DIFF
--- a/lib/lang.py
+++ b/lib/lang.py
@@ -163,7 +163,7 @@ punctuation_split_soft_set = set(punctuation_split_soft)
 
 chars_remove = [
     '\\', '|', '©', '®', '™',
-    '*', '`', '\u00A0', '"', '\xa0'
+    '*', '`', '\u00A0', '\xa0'
 ]
 
 roman_numbers_tuples = [


### PR DESCRIPTION
This PR fixes four things:

- The xtts engine has an issue where it will occasionally repeat the end of a long sentence. During testing, I believe the cause of this is because full stops are replaced with dashes in a sentence to indicate to the model to pause. But the code was replacing full stops including the final full stop of a sentence with a dash, and I believe this caused the model to hallucinate that the sentence needed to continue, and so it repeated the last few words. After making this change, I haven't had it hallucinate like this at all.
- The xtts engine was occasionally hallucinating around quotation marks, merging words together across the quotation boundary and mispronouncing words. To fix this I have removed the first quotation when it appears and replaced the second with a comma, which indicates that the model should pause. I've found this gives it much better performance when saying a quotation
- Sentence splitting had a bug where if a sentence ended with a quotation like "this is the end of the sentence.", it would not actually recognise that that full stop was the end of the sentence at all, and just continue on finding a break somewhere else, leading to some very unnatural sentence flow. I've had to preserve quotes when calculating sentence boundaries to fix this (reason for lang.py changing). 
- Sentence splitting had another bug where it would occasionally produce very short sentences of even just one word when a sentence got too long, just splitting a sentence up unnaturally when it hit the sentence character limit. I've added code to discourage it from doing this, and a post processing step to guarantee this won't happen if any sneak through. 