### PR TITLE
Fix --device CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,7 @@ to let the web page reconnect to the new connection socket.**
 <a id="help-command-output"></a>
 ```bash
 usage: app.py [-h] [--session SESSION] [--share] [--headless] [--ebook EBOOK] [--ebooks_dir EBOOKS_DIR]
-              [--language LANGUAGE] [--voice VOICE]
-              [--device {{'proc': 'cpu', 'found': True},{'proc': 'cuda', 'found': False},{'proc': 'mps', 'found': False},{'proc': 'rocm', 'found': False},{'proc': 'xpu', 'found': False}}]
+              [--language LANGUAGE] [--voice VOICE] [--device {CPU,CUDA,MPS,ROCM,XPU,JETSON}]
               [--tts_engine {XTTSv2,BARK,VITS,FAIRSEQ,TACOTRON2,YOURTTS,xtts,bark,vits,fairseq,tacotron,yourtts}]
               [--custom_model CUSTOM_MODEL] [--fine_tuned FINE_TUNED] [--output_format OUTPUT_FORMAT]
               [--output_channel OUTPUT_CHANNEL] [--temperature TEMPERATURE] [--length_penalty LENGTH_PENALTY]
@@ -264,8 +263,8 @@ options:
 optional parameters:
   --voice VOICE         (Optional) Path to the voice cloning file for TTS engine.
                             Uses the default voice if not present.
-  --device {{'proc': 'cpu', 'found': True},{'proc': 'cuda', 'found': False},{'proc': 'mps', 'found': False},{'proc': 'rocm', 'found': False},{'proc': 'xpu', 'found': False}}
-                        (Optional) Pprocessor unit type for the conversion.
+  --device {CPU,CUDA,MPS,ROCM,XPU,JETSON}
+                        (Optional) Processor unit type for the conversion.
                             Default is set in ./lib/conf.py if not present. Fall back to CPU if CUDA or MPS is not available.
   --tts_engine {XTTSv2,BARK,VITS,FAIRSEQ,TACOTRON2,YOURTTS,xtts,bark,vits,fairseq,tacotron,yourtts}
                         (Optional) Preferred TTS engine (available are: ['XTTSv2', 'BARK', 'VITS', 'FAIRSEQ', 'TACOTRON2', 'YOURTTS', 'xtts', 'bark', 'vits', 'fairseq', 'tacotron', 'yourtts'].

--- a/app.py
+++ b/app.py
@@ -163,7 +163,7 @@ Tip: to add of silence (1.4 seconds) into your text just use "###" or "[pause]".
     headless_optional_group = parser.add_argument_group('optional parameters')
     headless_optional_group.add_argument(options[7], type=str, default=None, help='''(Optional) Path to the voice cloning file for TTS engine. 
     Uses the default voice if not present.''')
-    headless_optional_group.add_argument(options[8], type=str, default=default_device, choices=list(devices.values()), help=f'''(Optional) Pprocessor unit type for the conversion. 
+    headless_optional_group.add_argument(options[8], type=str, default=default_device, choices=list(devices.keys()), help=f'''(Optional) Processor unit type for the conversion.
     Default is set in ./lib/conf.py if not present. Fall back to CPU if CUDA or MPS is not available.''')
     headless_optional_group.add_argument(options[9], type=str, default=None, choices=tts_engine_list_keys+tts_engine_list_values, help=f'''(Optional) Preferred TTS engine (available are: {tts_engine_list_keys+tts_engine_list_values}.
     Default depends on the selected language. The tts engine should be compatible with the chosen language''')


### PR DESCRIPTION
Hi! This is my first contribution here, please let me know if I'm not doing something I'm supposed to.

This fixes a bug where `--device` CLI argument had an incorrect list of allowed values, rendering it unusable.

#### Before
```bash
ebook2audiobook % ./ebook2audiobook.sh --headless --device MPS --ebook test.epub
usage: app.py [-h] [--session SESSION] [--share] [--headless] [--ebook EBOOK] [--ebooks_dir EBOOKS_DIR] [--language LANGUAGE]
              [--voice VOICE]
              [--device {{'proc': 'cpu', 'found': True},{'proc': 'cuda', 'found': False},{'proc': 'mps', 'found': False},{'proc': 'rocm', 'found': False},{'proc': 'xpu', 'found': False},{'proc': 'jetson', 'found': False}}]
              [--tts_engine {XTTSv2,BARK,VITS,FAIRSEQ,TACOTRON2,YOURTTS,xtts,bark,vits,fairseq,tacotron,yourtts}]
              [--custom_model CUSTOM_MODEL] [--fine_tuned FINE_TUNED] [--output_format OUTPUT_FORMAT] [--output_channel OUTPUT_CHANNEL]
              [--temperature TEMPERATURE] [--length_penalty LENGTH_PENALTY] [--num_beams NUM_BEAMS]
              [--repetition_penalty REPETITION_PENALTY] [--top_k TOP_K] [--top_p TOP_P] [--speed SPEED] [--enable_text_splitting]
              [--text_temp TEXT_TEMP] [--waveform_temp WAVEFORM_TEMP] [--output_dir OUTPUT_DIR] [--version]
app.py: error: argument --device: invalid choice: 'MPS' (choose from {'proc': 'cpu', 'found': True}, {'proc': 'cuda', 'found': False}, {'proc': 'mps', 'found': False}, {'proc': 'rocm', 'found': False}, {'proc': 'xpu', 'found': False}, {'proc': 'jetson', 'found': False})
```

#### After
```bash
ebook2audiobook % ./ebook2audiobook.sh --headless --device MPS --ebook test.epub
v25.12.25 native mode
---> Hardware detected: {'name': 'mps', 'os': 'macosx_11_0', 'arch': 'arm64', 'pyvenv': [3, 12], 'tag': 'mps', 'note': ''}
Installing the right library packages for mps...
...

ebook2audiobook % ./ebook2audiobook.sh --help
usage: app.py [-h] [--session SESSION] [--share] [--headless] [--ebook EBOOK] [--ebooks_dir EBOOKS_DIR]
              [--language LANGUAGE] [--voice VOICE] [--device {CPU,CUDA,MPS,ROCM,XPU,JETSON}]
              [--tts_engine {XTTSv2,BARK,VITS,FAIRSEQ,TACOTRON2,YOURTTS,xtts,bark,vits,fairseq,tacotron,yourtts}]
              [--custom_model CUSTOM_MODEL] [--fine_tuned FINE_TUNED] [--output_format OUTPUT_FORMAT]
              [--output_channel OUTPUT_CHANNEL] [--temperature TEMPERATURE] [--length_penalty LENGTH_PENALTY]
              [--num_beams NUM_BEAMS] [--repetition_penalty REPETITION_PENALTY] [--top_k TOP_K] [--top_p TOP_P]
              [--speed SPEED] [--enable_text_splitting] [--text_temp TEXT_TEMP] [--waveform_temp WAVEFORM_TEMP]
              [--output_dir OUTPUT_DIR] [--version]
...
```