### PR TITLE
fix: improve CUDA detection for WSL2 and newer CUDA versions

### DIFF
--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -266,6 +266,11 @@ class DeviceInstaller():
                 if has_cmd("lspci"):
                     out = try_cmd("lspci -nn").lower()
                     return "10de:" in out and (" vga " in out or " 3d " in out)
+                # WSL2: nvidia-smi works but PCI isn't exposed normally
+                if has_cmd("nvidia-smi"):
+                    out = try_cmd("nvidia-smi -L").lower()
+                    if "gpu" in out and "nvidia" in out:
+                        return True
                 return False
             # ---------- Windows ----------
             if os.name == "nt":

--- a/lib/conf.py
+++ b/lib/conf.py
@@ -131,7 +131,7 @@ torch_matrix = {
     "jetson61": {"url": default_jetson_url}
 }
 
-cuda_version_range = {"min": (11,8), "max": (12,8)}
+cuda_version_range = {"min": (11,8), "max": (13,1)}
 rocm_version_range = {"min": (5,5), "max": (6,4)}
 mps_version_range = {"min": (0,0), "max": (0,0)}
 xpu_version_range = {"min": (0,0), "max": (0,0)}


### PR DESCRIPTION
## Summary
- Add nvidia-smi fallback for GPU detection on Linux/WSL2 where PCI sysfs entries don't expose NVIDIA vendor IDs normally
- Extend CUDA version range max from 12.8 to 13.1 to support newer driver versions

## Problem
In WSL2 environments, CUDA was not being detected even though:
- `nvidia-smi` works correctly
- PyTorch reports `torch.cuda.is_available() = True`

The root cause is that WSL2 doesn't expose the GPU through the standard `/sys/bus/pci/devices` sysfs interface with vendor IDs, so `has_nvidia_gpu_pci()` was returning `False`.

## Solution
Added a fallback check using `nvidia-smi -L` when the PCI sysfs check fails on Linux. This enables CUDA detection in WSL2 and other environments where the GPU is available but not exposed through standard PCI enumeration.

Also extended the CUDA version range to support CUDA 13.1 (current drivers report 13.x).

## Test plan
- [x] Tested on WSL2 (Debian) with RTX 3080 Ti
- [x] CUDA now detected correctly: `{'name': 'cuda', 'tag': 'cu126'}`
- [x] TTS conversion works with GPU acceleration