### PR TITLE
fix(gradio): skip invalid restored slider values

### DIFF
--- a/lib/gradio.py
+++ b/lib/gradio.py
@@ -2402,9 +2402,18 @@ def build_interface(args:dict)->gr.Blocks:
                                         ];
                                         sliders.forEach(slider => {
                                             if(!slider) return;
-                                            const key = slider.closest("div[id]").id.replace(/^gr_/, "");
-                                            const saved = window.session_storage[key];
-                                            slider.value = (slider === gr_xtts_top_k) ? parseInt(saved) : parseFloat(saved);
+                                            const container = slider.closest("div[id]");
+                                            if(!container) return;
+                                            const key = container.id.replace(/^gr_/, "");
+                                            const saved = window.session_storage?.[key];
+                                            if(saved === undefined || saved === null || saved === ""){
+                                                return;
+                                            }
+                                            const parsed = (slider === gr_xtts_top_k) ? parseInt(saved, 10) : parseFloat(saved);
+                                            if(!Number.isFinite(parsed)){
+                                                return;
+                                            }
+                                            slider.value = parsed;
                                             slider.dispatchEvent(new Event("input", { bubbles: true }));
                                         });
                                     }catch(e){
@@ -2423,9 +2432,18 @@ def build_interface(args:dict)->gr.Blocks:
                                         ];
                                         sliders.forEach(slider => {
                                             if(!slider) return;
-                                            const key = slider.closest("div[id]").id.replace(/^gr_/, "");
-                                            const saved = window.session_storage[key];
-                                            slider.value = parseFloat(saved);
+                                            const container = slider.closest("div[id]");
+                                            if(!container) return;
+                                            const key = container.id.replace(/^gr_/, "");
+                                            const saved = window.session_storage?.[key];
+                                            if(saved === undefined || saved === null || saved === ""){
+                                                return;
+                                            }
+                                            const parsed = parseFloat(saved);
+                                            if(!Number.isFinite(parsed)){
+                                                return;
+                                            }
+                                            slider.value = parsed;
                                             slider.dispatchEvent(new Event("input", { bubbles: true }));
                                         });
                                     }catch(e){


### PR DESCRIPTION
## Summary
Fixes a Gradio crash when processing conversion after slider values are restored from browser session storage.

## Root cause
Slider restore JS parsed missing/invalid saved values and wrote them into numeric inputs.
That could produce `None` payloads in Gradio preprocess, causing:
`TypeError: '<' not supported between instances of 'NoneType' and 'int/float'`.

## Changes
- Updated slider restore logic in `lib/gradio.py`:
  - skip restore when saved value is missing/empty
  - parse safely (`parseInt(..., 10)` / `parseFloat(...)`)
  - apply only finite values (`Number.isFinite(...)`)
- Leaves default slider values untouched when saved values are invalid.

## Validation
- `python3 -m py_compile lib/gradio.py`
- Manual: restart app, open UI, switch tabs, run conversion without slider preprocess errors.
