### PR TITLE
feat: add MiniMax cloud TTS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ https://github.com/user-attachments/assets/81c4baad-117e-4db5-ac86-efc2b7fea921
 
 
 ## Features
-- 🔧 **TTS Engines supported**: `XTTSv2`, `Bark`, `Fairseq`, `VITS`, `Tacotron2`, `Tortoise`, `GlowTTS`, `YourTTS`
+- 🔧 **TTS Engines supported**: `XTTSv2`, `Bark`, `Fairseq`, `VITS`, `Tacotron2`, `Tortoise`, `GlowTTS`, `YourTTS`, `MiniMax`
 - 📚 **Convert multiple file formats**: `.epub`, `.mobi`, `.azw3`, `.fb2`, `.lrf`, `.rb`, `.snb`, `.tcr`, `.pdf`, `.txt`, `.rtf`, `.doc`, `.docx`, `.html`, `.odt`, `.azw`, `.tiff`, `.tif`, `.png`, `.jpg`, `.jpeg`, `.bmp`
 - 🔍 **OCR scanning** for files with text pages as images
 - 🔊 **High-quality text-to-speech** from near realtime to near real voice
@@ -124,6 +124,21 @@ https://github.com/user-attachments/assets/81c4baad-117e-4db5-ac86-efc2b7fea921
 - MPS (Apple Silicon CPU)
 
 *<i> Modern TTS engines are very slow on CPU, so use lower quality TTS like YourTTS, Tacotron2 etc..</i>
+
+### MiniMax Cloud TTS
+
+[MiniMax](https://platform.minimax.io) is a cloud-based TTS engine that requires no GPU and produces high-quality speech.
+
+- **API Key**: Set `MINIMAX_API_KEY` environment variable
+- **Base URL**: `https://api.minimax.io` (global) / `https://api.minimaxi.com` (China)
+- **Models**: `speech-2.8-hd` (default, highest quality), `speech-2.8-turbo` (faster)
+- **Voices**: Graceful Lady, Insightful Speaker, Radiant Girl, Persuasive Man, Lucky Robot, Expressive Narrator
+
+```bash
+# Example usage with MiniMax TTS
+export MINIMAX_API_KEY="your-api-key"
+python app.py --headless --ebook mybook.epub --tts_engine MINIMAX --fine_tuned speech-2.8-hd
+```
 
 ## Supported Languages
 | **Arabic (ar)**    | **Chinese (zh)**    | **English (en)**   | **Spanish (es)**   |

--- a/lib/classes/tts_engines/__init__.py
+++ b/lib/classes/tts_engines/__init__.py
@@ -6,3 +6,4 @@ from .fairseq import Fairseq
 from .tortoise import Tortoise
 from .tacotron import Tacotron2
 from .yourtts import YourTTS
+from .minimax import MiniMax

--- a/lib/classes/tts_engines/minimax.py
+++ b/lib/classes/tts_engines/minimax.py
@@ -1,0 +1,256 @@
+import os
+import json
+import shutil
+import tempfile
+import subprocess
+
+from typing import Any
+from pathlib import Path
+from multiprocessing.managers import DictProxy
+
+from lib.classes.tts_registry import TTSRegistry
+from lib.classes.tts_engines.common.preset_loader import load_engine_presets
+from lib.classes.tts_engines.common.audio import get_audiolist_duration
+from lib.conf import default_audio_proc_format
+from lib.conf_models import TTS_ENGINES, SML_TAG_PATTERN
+
+try:
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError, URLError
+except ImportError:
+    pass
+
+
+MINIMAX_VOICES = {
+    "English_Graceful_Lady": "Graceful Lady",
+    "English_Insightful_Speaker": "Insightful Speaker",
+    "English_radiant_girl": "Radiant Girl",
+    "English_Persuasive_Man": "Persuasive Man",
+    "English_Lucky_Robot": "Lucky Robot",
+    "English_expressive_narrator": "Expressive Narrator",
+}
+
+
+class MiniMax(TTSRegistry, name='minimax'):
+
+    def __init__(self, session: DictProxy):
+        try:
+            self.session = session
+            self.models = load_engine_presets(self.session['tts_engine'])
+            self.params = {}
+            fine_tuned = self.session.get('fine_tuned')
+            if fine_tuned not in self.models:
+                error = f'Invalid fine_tuned model {fine_tuned}. Available models: {list(self.models.keys())}'
+                raise ValueError(error)
+            model_cfg = self.models[fine_tuned]
+            for required_key in ('samplerate',):
+                if required_key not in model_cfg:
+                    error = f'fine_tuned model {fine_tuned} is missing required key {required_key}.'
+                    raise ValueError(error)
+            self.params['samplerate'] = model_cfg['samplerate']
+            self.params['model'] = model_cfg.get('model', 'speech-2.8-hd')
+            self.params['default_voice'] = model_cfg.get('voice', 'English_Graceful_Lady')
+            self.api_key = os.environ.get('MINIMAX_API_KEY', '')
+            self.base_url = os.environ.get('MINIMAX_BASE_URL', 'https://api.minimax.io')
+            if not self.api_key:
+                error = 'MINIMAX_API_KEY environment variable is required for MiniMax TTS engine'
+                raise ValueError(error)
+            msg = f'MiniMax TTS engine initialized (model: {self.params["model"]})'
+            print(msg)
+        except Exception as e:
+            error = f'__init__() error: {e}'
+            raise ValueError(error)
+
+    def _get_voice_id(self) -> str:
+        voice = self.session.get('voice')
+        if voice and voice in MINIMAX_VOICES:
+            return voice
+        return self.params['default_voice']
+
+    def _synthesize(self, text: str, voice_id: str) -> bytes:
+        url = f'{self.base_url}/v1/t2a_v2'
+        payload = {
+            'model': self.params['model'],
+            'text': text,
+            'stream': False,
+            'voice_setting': {
+                'voice_id': voice_id,
+                'speed': 1,
+                'vol': 1,
+                'pitch': 0,
+            },
+            'audio_setting': {
+                'sample_rate': self.params['samplerate'],
+                'bitrate': 128000,
+                'format': 'mp3',
+                'channel': 1,
+            },
+        }
+        language = self.session.get('language', '')
+        if language:
+            iso1 = self.session.get('language_iso1', '')
+            if iso1 == 'en':
+                payload['language_boost'] = 'English'
+            elif iso1 == 'zh' or iso1 == 'zh-cn':
+                payload['language_boost'] = 'Chinese'
+            else:
+                payload['language_boost'] = 'auto'
+
+        req_data = json.dumps(payload).encode('utf-8')
+        req = Request(
+            url,
+            data=req_data,
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {self.api_key}',
+            },
+        )
+        try:
+            resp = urlopen(req, timeout=120)
+            result = json.loads(resp.read().decode('utf-8'))
+        except HTTPError as e:
+            body = e.read().decode('utf-8', errors='replace')
+            error = f'MiniMax TTS API error {e.code}: {body}'
+            raise RuntimeError(error) from e
+        except URLError as e:
+            error = f'MiniMax TTS network error: {e.reason}'
+            raise RuntimeError(error) from e
+
+        status_code = result.get('base_resp', {}).get('status_code', -1)
+        if status_code != 0:
+            status_msg = result.get('base_resp', {}).get('status_msg', 'unknown error')
+            error = f'MiniMax TTS error (code {status_code}): {status_msg}'
+            raise RuntimeError(error)
+
+        hex_audio = result.get('data', {}).get('audio', '')
+        if not hex_audio:
+            error = 'MiniMax TTS returned empty audio data'
+            raise RuntimeError(error)
+
+        return bytes.fromhex(hex_audio)
+
+    def _mp3_to_target_format(self, mp3_data: bytes, output_path: str) -> bool:
+        ffmpeg = shutil.which('ffmpeg')
+        if not ffmpeg:
+            error = 'ffmpeg not found, required for audio format conversion'
+            print(error)
+            return False
+
+        tmp_dir = os.path.dirname(output_path)
+        with tempfile.NamedTemporaryFile(dir=tmp_dir, suffix='.mp3', delete=False) as tmp:
+            tmp.write(mp3_data)
+            tmp_mp3 = tmp.name
+
+        try:
+            cmd = [
+                ffmpeg, '-hide_banner', '-nostats', '-loglevel', 'error',
+                '-i', tmp_mp3,
+                '-ar', str(self.params['samplerate']),
+                '-ac', '1',
+                '-y', output_path,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                error = f'ffmpeg conversion error: {result.stderr}'
+                print(error)
+                return False
+            return os.path.exists(output_path)
+        except Exception as e:
+            error = f'_mp3_to_target_format() error: {e}'
+            print(error)
+            return False
+        finally:
+            Path(tmp_mp3).unlink(missing_ok=True)
+
+    def convert(self, sentence_index: int, sentence: str) -> bool:
+        try:
+            final_sentence_file = os.path.join(
+                self.session['sentences_dir'],
+                f'{sentence_index}.{default_audio_proc_format}',
+            )
+            clean_text = SML_TAG_PATTERN.sub('', sentence).strip()
+            if not clean_text or not any(c.isalnum() for c in clean_text):
+                clean_text = '...'
+
+            voice_id = self._get_voice_id()
+            mp3_data = self._synthesize(clean_text, voice_id)
+            if not self._mp3_to_target_format(mp3_data, final_sentence_file):
+                error = f'Failed to convert MP3 to {default_audio_proc_format}'
+                print(error)
+                return False
+
+            if not os.path.exists(final_sentence_file):
+                error = f'Cannot create {final_sentence_file}'
+                print(error)
+                return False
+
+            return True
+        except Exception as e:
+            error = f'MiniMax.convert(): {e}'
+            print(error)
+            return False
+
+    def create_vtt(self, all_sentences: list) -> bool:
+        try:
+            from tqdm import tqdm
+            audio_dir = self.session['sentences_dir']
+            vtt_path = os.path.join(
+                self.session['process_dir'],
+                Path(self.session['final_name']).stem + '.vtt',
+            )
+            audio_sentences_dir = Path(audio_dir)
+            audio_files = sorted(
+                audio_sentences_dir.glob(f'*.{default_audio_proc_format}'),
+                key=lambda p: int(p.stem),
+            )
+            audio_files_length = len(audio_files)
+            all_sentences_length = len(all_sentences)
+
+            expected_indices = list(range(audio_files_length))
+            actual_indices = [int(p.stem) for p in audio_files]
+            if actual_indices != expected_indices:
+                missing = sorted(set(expected_indices) - set(actual_indices))
+                error = f'Missing audio sentence files: {missing}'
+                print(error)
+                return False
+
+            if audio_files_length != all_sentences_length:
+                error = f'Audio/sentence mismatch: {audio_files_length} audio files vs {all_sentences_length} sentences'
+                print(error)
+                return False
+
+            sentences_total_time = 0.0
+            vtt_blocks = []
+
+            durations = get_audiolist_duration([str(p) for p in audio_files])
+
+            with tqdm(total=audio_files_length, unit='files') as t:
+                for idx, file in enumerate(audio_files):
+                    start_time = sentences_total_time
+                    duration = durations.get(os.path.realpath(file), 0.0)
+                    end_time = start_time + duration
+                    sentences_total_time = end_time
+
+                    m, s = divmod(start_time, 60)
+                    h, m = divmod(m, 60)
+                    start = f'{int(h):02}:{int(m):02}:{s:06.3f}'
+                    m, s = divmod(end_time, 60)
+                    h, m = divmod(m, 60)
+                    end = f'{int(h):02}:{int(m):02}:{s:06.3f}'
+
+                    import regex as re
+                    text = re.sub(
+                        r'\s+', ' ',
+                        SML_TAG_PATTERN.sub('', str(all_sentences[idx])),
+                    ).strip()
+                    vtt_blocks.append(f'{start} --> {end}\n{text}\n')
+                    t.update(1)
+
+            with open(vtt_path, 'w', encoding='utf-8') as f:
+                f.write('WEBVTT\n\n')
+                f.write('\n'.join(vtt_blocks))
+            return True
+        except Exception as e:
+            error = f'MiniMax.create_vtt(): {e}'
+            print(error)
+            return False

--- a/lib/classes/tts_engines/presets/minimax_presets.py
+++ b/lib/classes/tts_engines/presets/minimax_presets.py
@@ -1,0 +1,18 @@
+from lib.conf_models import TTS_ENGINES, default_engine_settings
+
+models = {
+    "speech-2.8-hd": {
+        "lang": "multi",
+        "model": "speech-2.8-hd",
+        "repo": "minimax/speech-2.8-hd",
+        "voice": "English_Graceful_Lady",
+        "samplerate": default_engine_settings[TTS_ENGINES['MINIMAX']]['samplerate'],
+    },
+    "speech-2.8-turbo": {
+        "lang": "multi",
+        "model": "speech-2.8-turbo",
+        "repo": "minimax/speech-2.8-turbo",
+        "voice": "English_Graceful_Lady",
+        "samplerate": default_engine_settings[TTS_ENGINES['MINIMAX']]['samplerate'],
+    },
+}

--- a/lib/conf_models.py
+++ b/lib/conf_models.py
@@ -12,7 +12,8 @@ TTS_ENGINES = {
     "FAIRSEQ": "fairseq",
     "GLOWTTS": "glowtts",
     "TACOTRON2": "tacotron",
-    "YOURTTS": "yourtts"
+    "YOURTTS": "yourtts",
+    "MINIMAX": "minimax"
 }
 
 TTS_VOICE_CONVERSION = {
@@ -190,5 +191,18 @@ default_engine_settings = {
         "files": ['config.json', 'model_file.pth'],
         "voices": {"Machinella-5": "female-en-5", "ElectroMale-2": "male-en-2", 'Machinella-4': 'female-pt-4\n', 'ElectroMale-3': 'male-pt-3\n'},
         "rating": {"VRAM": 1, "CPU": 5, "RAM": 1, "Realism": 2}
+    },
+    TTS_ENGINES['MINIMAX']: {
+        "languages": {"eng": "en", "zho": "zh-cn", "jpn": "ja", "kor": "ko", "fra": "fr", "deu": "de", "spa": "es", "ita": "it", "por": "pt", "rus": "ru", "tur": "tr", "ara": "ar", "hin": "hi"},
+        "samplerate": 32000,
+        "voices": {
+            "English_Graceful_Lady": "Graceful Lady",
+            "English_Insightful_Speaker": "Insightful Speaker",
+            "English_radiant_girl": "Radiant Girl",
+            "English_Persuasive_Man": "Persuasive Man",
+            "English_Lucky_Robot": "Lucky Robot",
+            "English_expressive_narrator": "Expressive Narrator",
+        },
+        "rating": {"VRAM": 0, "CPU": 1, "RAM": 1, "Realism": 5}
     }
 }

--- a/tests/test_minimax_tts.py
+++ b/tests/test_minimax_tts.py
@@ -1,0 +1,287 @@
+"""Unit tests for MiniMax TTS engine."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+class TestMiniMaxConfig(unittest.TestCase):
+    """Test MiniMax TTS configuration and registration."""
+
+    def test_engine_registered_in_tts_engines(self):
+        from lib.conf_models import TTS_ENGINES
+        self.assertIn('MINIMAX', TTS_ENGINES)
+        self.assertEqual(TTS_ENGINES['MINIMAX'], 'minimax')
+
+    def test_engine_registered_in_default_settings(self):
+        from lib.conf_models import TTS_ENGINES, default_engine_settings
+        self.assertIn(TTS_ENGINES['MINIMAX'], default_engine_settings)
+
+    def test_default_settings_have_required_fields(self):
+        from lib.conf_models import TTS_ENGINES, default_engine_settings
+        settings = default_engine_settings[TTS_ENGINES['MINIMAX']]
+        self.assertIn('languages', settings)
+        self.assertIn('samplerate', settings)
+        self.assertIn('voices', settings)
+        self.assertIn('rating', settings)
+
+    def test_samplerate_is_valid(self):
+        from lib.conf_models import TTS_ENGINES, default_engine_settings
+        settings = default_engine_settings[TTS_ENGINES['MINIMAX']]
+        self.assertEqual(settings['samplerate'], 32000)
+
+    def test_voices_not_empty(self):
+        from lib.conf_models import TTS_ENGINES, default_engine_settings
+        settings = default_engine_settings[TTS_ENGINES['MINIMAX']]
+        self.assertGreater(len(settings['voices']), 0)
+        self.assertIn('English_Graceful_Lady', settings['voices'])
+
+    def test_english_language_supported(self):
+        from lib.conf_models import TTS_ENGINES, default_engine_settings
+        settings = default_engine_settings[TTS_ENGINES['MINIMAX']]
+        self.assertIn('eng', settings['languages'])
+        self.assertEqual(settings['languages']['eng'], 'en')
+
+    def test_rating_no_vram_required(self):
+        from lib.conf_models import TTS_ENGINES, default_engine_settings
+        settings = default_engine_settings[TTS_ENGINES['MINIMAX']]
+        self.assertEqual(settings['rating']['VRAM'], 0)
+
+    def test_engine_in_tts_registry(self):
+        from lib.classes.tts_registry import TTSRegistry
+        # Force import to trigger registration
+        from lib.classes.tts_engines.minimax import MiniMax
+        self.assertIn('minimax', TTSRegistry.ENGINES)
+        self.assertEqual(TTSRegistry.ENGINES['minimax'], MiniMax)
+
+
+class TestMiniMaxPresets(unittest.TestCase):
+    """Test MiniMax TTS preset models."""
+
+    def test_presets_loadable(self):
+        from lib.classes.tts_engines.presets.minimax_presets import models
+        self.assertIsInstance(models, dict)
+        self.assertGreater(len(models), 0)
+
+    def test_preset_speech_28_hd(self):
+        from lib.classes.tts_engines.presets.minimax_presets import models
+        self.assertIn('speech-2.8-hd', models)
+        hd = models['speech-2.8-hd']
+        self.assertEqual(hd['model'], 'speech-2.8-hd')
+        self.assertIn('samplerate', hd)
+        self.assertIn('voice', hd)
+
+    def test_preset_speech_28_turbo(self):
+        from lib.classes.tts_engines.presets.minimax_presets import models
+        self.assertIn('speech-2.8-turbo', models)
+        turbo = models['speech-2.8-turbo']
+        self.assertEqual(turbo['model'], 'speech-2.8-turbo')
+
+    def test_preset_default_voice(self):
+        from lib.classes.tts_engines.presets.minimax_presets import models
+        for name, preset in models.items():
+            self.assertIn('voice', preset, f'Preset {name} missing voice')
+            self.assertEqual(preset['voice'], 'English_Graceful_Lady')
+
+
+class TestMiniMaxEngine(unittest.TestCase):
+    """Test MiniMax TTS engine initialization and methods."""
+
+    def _make_session(self, **overrides):
+        defaults = {
+            'tts_engine': 'minimax',
+            'fine_tuned': 'speech-2.8-hd',
+            'model_cache': 'minimax-speech-2.8-hd',
+            'sentences_dir': '/tmp/test_sentences',
+            'process_dir': '/tmp/test_process',
+            'final_name': 'test.m4b',
+            'voice': None,
+            'language': 'eng',
+            'language_iso1': 'en',
+            'device': 'cpu',
+            'free_vram_gb': 0,
+            'is_gui_process': False,
+            'custom_model': None,
+            'custom_model_dir': '/tmp/custom',
+        }
+        defaults.update(overrides)
+        return defaults
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-api-key'})
+    def test_init_with_api_key(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session()
+        engine = MiniMax(session)
+        self.assertEqual(engine.api_key, 'test-api-key')
+        self.assertEqual(engine.params['model'], 'speech-2.8-hd')
+        self.assertEqual(engine.params['samplerate'], 32000)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_without_api_key_fails(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        # Remove MINIMAX_API_KEY if set
+        os.environ.pop('MINIMAX_API_KEY', None)
+        session = self._make_session()
+        with self.assertRaises(ValueError) as ctx:
+            MiniMax(session)
+        self.assertIn('MINIMAX_API_KEY', str(ctx.exception))
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_init_invalid_fine_tuned(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session(fine_tuned='nonexistent-model')
+        with self.assertRaises(ValueError) as ctx:
+            MiniMax(session)
+        self.assertIn('Invalid fine_tuned model', str(ctx.exception))
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_get_voice_id_default(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session(voice=None)
+        engine = MiniMax(session)
+        self.assertEqual(engine._get_voice_id(), 'English_Graceful_Lady')
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_get_voice_id_custom(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session(voice='English_Persuasive_Man')
+        engine = MiniMax(session)
+        self.assertEqual(engine._get_voice_id(), 'English_Persuasive_Man')
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_get_voice_id_invalid_falls_back(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session(voice='/some/local/file.wav')
+        engine = MiniMax(session)
+        self.assertEqual(engine._get_voice_id(), 'English_Graceful_Lady')
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_custom_base_url(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        os.environ['MINIMAX_BASE_URL'] = 'https://api.minimaxi.com'
+        try:
+            session = self._make_session()
+            engine = MiniMax(session)
+            self.assertEqual(engine.base_url, 'https://api.minimaxi.com')
+        finally:
+            os.environ.pop('MINIMAX_BASE_URL', None)
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_turbo_model_preset(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session(fine_tuned='speech-2.8-turbo')
+        engine = MiniMax(session)
+        self.assertEqual(engine.params['model'], 'speech-2.8-turbo')
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_synthesize_request_format(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session()
+        engine = MiniMax(session)
+
+        # Mock urlopen to capture the request
+        hex_audio = b'ID3'.hex()
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            'data': {'audio': hex_audio, 'status': 2},
+            'base_resp': {'status_code': 0, 'status_msg': 'success'},
+        }).encode()
+
+        with patch('lib.classes.tts_engines.minimax.urlopen', return_value=mock_response) as mock_url:
+            result = engine._synthesize('Hello world', 'English_Graceful_Lady')
+            self.assertEqual(result, bytes.fromhex(hex_audio))
+
+            # Verify request was made
+            call_args = mock_url.call_args
+            req = call_args[0][0]
+            self.assertIn('/v1/t2a_v2', req.full_url)
+            self.assertEqual(req.get_header('Authorization'), 'Bearer test-key')
+            body = json.loads(req.data.decode())
+            self.assertEqual(body['model'], 'speech-2.8-hd')
+            self.assertEqual(body['text'], 'Hello world')
+            self.assertEqual(body['voice_setting']['voice_id'], 'English_Graceful_Lady')
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_synthesize_api_error(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session()
+        engine = MiniMax(session)
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            'data': {},
+            'base_resp': {'status_code': 1004, 'status_msg': 'authentication failed'},
+        }).encode()
+
+        with patch('lib.classes.tts_engines.minimax.urlopen', return_value=mock_response):
+            with self.assertRaises(RuntimeError) as ctx:
+                engine._synthesize('Hello', 'English_Graceful_Lady')
+            self.assertIn('1004', str(ctx.exception))
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_convert_strips_sml_tags(self):
+        from lib.classes.tts_engines.minimax import MiniMax
+        session = self._make_session()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session['sentences_dir'] = tmpdir
+            engine = MiniMax(session)
+
+            hex_audio = b'\xff\xfb\x90\x00'.hex()
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({
+                'data': {'audio': hex_audio, 'status': 2},
+                'base_resp': {'status_code': 0, 'status_msg': 'success'},
+            }).encode()
+
+            with patch('lib.classes.tts_engines.minimax.urlopen', return_value=mock_response) as mock_url, \
+                 patch.object(engine, '_mp3_to_target_format', return_value=True) as mock_conv:
+                # Sentence with SML tags
+                engine.convert(0, 'Hello [break] world [pause:0.5] end')
+
+                # Check that SML tags are stripped
+                call_args = mock_url.call_args
+                req = call_args[0][0]
+                body = json.loads(req.data.decode())
+                self.assertNotIn('[break]', body['text'])
+                self.assertNotIn('[pause', body['text'])
+                self.assertIn('Hello', body['text'])
+                self.assertIn('world', body['text'])
+
+
+class TestMiniMaxTTSManager(unittest.TestCase):
+    """Test that MiniMax works with TTSManager."""
+
+    @patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'})
+    def test_tts_manager_loads_minimax(self):
+        from lib.classes.tts_manager import TTSManager
+        session = {
+            'tts_engine': 'minimax',
+            'fine_tuned': 'speech-2.8-hd',
+            'model_cache': 'minimax-speech-2.8-hd',
+            'sentences_dir': '/tmp/test',
+            'process_dir': '/tmp/test',
+            'final_name': 'test.m4b',
+            'voice': None,
+            'language': 'eng',
+            'language_iso1': 'en',
+            'device': 'cpu',
+            'free_vram_gb': 0,
+            'is_gui_process': False,
+            'custom_model': None,
+            'custom_model_dir': '/tmp/custom',
+        }
+        manager = TTSManager(session)
+        from lib.classes.tts_engines.minimax import MiniMax
+        self.assertIsInstance(manager.engine, MiniMax)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_minimax_tts_integration.py
+++ b/tests/test_minimax_tts_integration.py
@@ -1,0 +1,178 @@
+"""Integration tests for MiniMax TTS engine using live API."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+API_KEY = os.environ.get('MINIMAX_API_KEY', '')
+BASE_URL = os.environ.get('MINIMAX_BASE_URL', 'https://api.minimax.io')
+
+
+@unittest.skipUnless(API_KEY, 'MINIMAX_API_KEY not set, skipping integration tests')
+class TestMiniMaxTTSIntegration(unittest.TestCase):
+    """Integration tests that call the real MiniMax TTS API."""
+
+    def test_synthesize_basic(self):
+        """Test basic speech synthesis returns valid audio."""
+        from lib.classes.tts_engines.minimax import MiniMax
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session = {
+                'tts_engine': 'minimax',
+                'fine_tuned': 'speech-2.8-hd',
+                'model_cache': 'minimax-speech-2.8-hd',
+                'sentences_dir': tmpdir,
+                'process_dir': tmpdir,
+                'final_name': 'test.m4b',
+                'voice': None,
+                'language': 'eng',
+                'language_iso1': 'en',
+                'device': 'cpu',
+                'free_vram_gb': 0,
+                'is_gui_process': False,
+                'custom_model': None,
+                'custom_model_dir': tmpdir,
+            }
+            engine = MiniMax(session)
+            audio_data = engine._synthesize(
+                'Hello, this is a MiniMax TTS test.',
+                'English_Graceful_Lady',
+            )
+            self.assertIsInstance(audio_data, bytes)
+            self.assertGreater(len(audio_data), 100)
+
+    def test_convert_creates_audio_file(self):
+        """Test full convert pipeline creates an audio file."""
+        from lib.classes.tts_engines.minimax import MiniMax
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session = {
+                'tts_engine': 'minimax',
+                'fine_tuned': 'speech-2.8-hd',
+                'model_cache': 'minimax-speech-2.8-hd',
+                'sentences_dir': tmpdir,
+                'process_dir': tmpdir,
+                'final_name': 'test.m4b',
+                'voice': None,
+                'language': 'eng',
+                'language_iso1': 'en',
+                'device': 'cpu',
+                'free_vram_gb': 0,
+                'is_gui_process': False,
+                'custom_model': None,
+                'custom_model_dir': tmpdir,
+            }
+            engine = MiniMax(session)
+            result = engine.convert(0, 'This is sentence number one for audiobook.')
+            self.assertTrue(result, 'convert() should return True on success')
+
+            from lib.conf import default_audio_proc_format
+            output_file = os.path.join(tmpdir, f'0.{default_audio_proc_format}')
+            self.assertTrue(
+                os.path.exists(output_file),
+                f'Output file should exist: {output_file}',
+            )
+            self.assertGreater(
+                os.path.getsize(output_file), 100,
+                'Output file should have content',
+            )
+
+    def test_convert_with_different_voice(self):
+        """Test convert with a specific voice ID."""
+        from lib.classes.tts_engines.minimax import MiniMax
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session = {
+                'tts_engine': 'minimax',
+                'fine_tuned': 'speech-2.8-hd',
+                'model_cache': 'minimax-speech-2.8-hd',
+                'sentences_dir': tmpdir,
+                'process_dir': tmpdir,
+                'final_name': 'test.m4b',
+                'voice': 'English_Persuasive_Man',
+                'language': 'eng',
+                'language_iso1': 'en',
+                'device': 'cpu',
+                'free_vram_gb': 0,
+                'is_gui_process': False,
+                'custom_model': None,
+                'custom_model_dir': tmpdir,
+            }
+            engine = MiniMax(session)
+            result = engine.convert(0, 'Testing with a male voice.')
+            self.assertTrue(result)
+
+    def test_convert_turbo_model(self):
+        """Test convert with the turbo model."""
+        from lib.classes.tts_engines.minimax import MiniMax
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session = {
+                'tts_engine': 'minimax',
+                'fine_tuned': 'speech-2.8-turbo',
+                'model_cache': 'minimax-speech-2.8-turbo',
+                'sentences_dir': tmpdir,
+                'process_dir': tmpdir,
+                'final_name': 'test.m4b',
+                'voice': None,
+                'language': 'eng',
+                'language_iso1': 'en',
+                'device': 'cpu',
+                'free_vram_gb': 0,
+                'is_gui_process': False,
+                'custom_model': None,
+                'custom_model_dir': tmpdir,
+            }
+            engine = MiniMax(session)
+            result = engine.convert(0, 'Testing with the turbo model.')
+            self.assertTrue(result)
+
+    def test_tts_api_direct(self):
+        """Test direct TTS API call with raw HTTP."""
+        from urllib.request import Request, urlopen
+
+        payload = {
+            'model': 'speech-2.8-hd',
+            'text': 'MiniMax integration test.',
+            'stream': False,
+            'voice_setting': {
+                'voice_id': 'English_Graceful_Lady',
+                'speed': 1,
+                'vol': 1,
+                'pitch': 0,
+            },
+            'audio_setting': {
+                'sample_rate': 32000,
+                'bitrate': 128000,
+                'format': 'mp3',
+                'channel': 1,
+            },
+        }
+
+        req = Request(
+            f'{BASE_URL}/v1/t2a_v2',
+            data=json.dumps(payload).encode(),
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {API_KEY}',
+            },
+        )
+        resp = urlopen(req, timeout=60)
+        result = json.loads(resp.read().decode())
+
+        self.assertEqual(result['base_resp']['status_code'], 0)
+        self.assertIn('audio', result['data'])
+        self.assertGreater(len(result['data']['audio']), 0)
+        self.assertEqual(result['data']['status'], 2)
+
+        # Verify hex decoding works
+        audio_bytes = bytes.fromhex(result['data']['audio'])
+        self.assertGreater(len(audio_bytes), 100)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add **MiniMax** as a cloud-based TTS engine, enabling high-quality speech synthesis without requiring a local GPU
- Uses the [MiniMax T2A v2 API](https://platform.minimax.io) with speech-2.8-hd and speech-2.8-turbo models
- Supports 6 built-in voices across 13 languages, zero VRAM required

## Changes

- **New engine**: `lib/classes/tts_engines/minimax.py` — inherits `TTSRegistry` for auto-registration, uses stdlib `urllib` (no new dependencies)
- **Presets**: `lib/classes/tts_engines/presets/minimax_presets.py` — speech-2.8-hd and speech-2.8-turbo model configurations
- **Config**: registered in `TTS_ENGINES` dict and `default_engine_settings` in `lib/conf_models.py`
- **Import**: added to `lib/classes/tts_engines/__init__.py`
- **Docs**: README updated with MiniMax Cloud TTS section and usage example
- **Tests**: 24 unit tests + 5 integration tests (29 total, all passing)

## How it works

1. User sets `MINIMAX_API_KEY` environment variable
2. Selects engine via `--tts_engine MINIMAX --fine_tuned speech-2.8-hd`
3. Engine calls MiniMax T2A v2 API, receives hex-encoded MP3 audio
4. Converts MP3 to FLAC (project default) via ffmpeg (already a project dependency)

## Test plan

- [x] 24 unit tests pass (config, presets, engine init, voice selection, API mocking, SML tag stripping, TTSManager integration)
- [x] 5 integration tests pass against live MiniMax API (basic synthesis, full convert pipeline, different voices, turbo model, direct API)
- [ ] Manual test: `python app.py --headless --ebook sample.epub --tts_engine MINIMAX --fine_tuned speech-2.8-hd`
