### PR TITLE
feat: add Camb AI cloud TTS engine

### DIFF
--- a/lib/classes/tts_engines/__init__.py
+++ b/lib/classes/tts_engines/__init__.py
@@ -6,3 +6,4 @@ from .fairseq import Fairseq
 from .tortoise import Tortoise
 from .tacotron import Tacotron2
 from .yourtts import YourTTS
+from .cambai import CambAI

--- a/lib/classes/tts_engines/cambai.py
+++ b/lib/classes/tts_engines/cambai.py
@@ -1,0 +1,92 @@
+from lib.classes.tts_engines.common.headers import *
+from lib.classes.tts_engines.common.preset_loader import load_engine_presets
+from dotenv import load_dotenv
+import logging
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+class CambAI(TTSUtils, TTSRegistry, name='cambai'):
+
+    def __init__(self, session:DictProxy):
+        try:
+            self.session = session
+            self.cache_dir = tts_dir
+            self.resampler_cache = {}
+            self.audio_segments = []
+            self.models = load_engine_presets('cambai')
+            self.params = {}
+
+            fine_tuned = self.session.get('fine_tuned', 'mars-flash')
+            if fine_tuned not in self.models:
+                fine_tuned = 'mars-flash'
+            model_cfg = self.models[fine_tuned]
+
+            self.params['samplerate'] = model_cfg.get('samplerate', 22050)
+            self.speech_model = model_cfg.get('speech_model', 'mars-flash')
+            self.voice_id = self.session.get('voice_id', model_cfg.get('voice_id', 147320))
+            from lib.conf_models import default_engine_settings, TTS_ENGINES
+            lang_map = default_engine_settings[TTS_ENGINES['CAMBAI']].get('languages', {})
+            lang_key = self.session.get('language', 'eng')
+            self.language = lang_map.get(lang_key, 'en-us')
+
+            # Init CAMB AI client
+            api_key = self.session.get('cambai_api_key', os.environ.get('CAMB_API_KEY', ''))
+            if not api_key:
+                raise ValueError("CAMB AI API key is required. Set cambai_api_key in session or CAMB_API_KEY env var.")
+
+            from camb.client import CambAI as CambClient
+            self.client = CambClient(api_key=api_key)
+            self.engine = self.load_engine()
+        except Exception as e:
+            error = f'__init__() error: {e}'
+            raise ValueError(error)
+
+    def load_engine(self)->Any:
+        msg = f"Loading CAMB AI TTS engine…"
+        print(msg)
+        return self.client
+
+    def convert(self, sentence_index:int, sentence:str)->bool:
+        try:
+            from camb.client import save_stream_to_file
+
+            final_sentence_file = os.path.join(
+                self.session['sentences_dir'],
+                f'{sentence_index}.{default_audio_proc_format}'
+            )
+
+            response = self.client.text_to_speech.tts(
+                text=sentence,
+                voice_id=int(self.voice_id),
+                language=self.language,
+                speech_model=self.speech_model
+            )
+
+            save_stream_to_file(response, final_sentence_file)
+
+            if not os.path.exists(final_sentence_file):
+                error = f"Cannot create {final_sentence_file}"
+                print(error)
+                return False
+
+            logger.info(f"CambAI TTS: Converted sentence {sentence_index} -> {final_sentence_file}")
+            return True
+        except Exception as e:
+            error = f'CambAI.convert(): {e}'
+            print(error)
+            logger.error(f"CambAI TTS error on sentence {sentence_index}: {e}")
+            return False
+
+    def create_vtt(self, all_sentences:list)->bool:
+        try:
+            audio_dir = self.session['sentences_dir']
+            vtt_path = os.path.join(self.session['process_dir'], Path(self.session['final_name']).stem + '.vtt')
+            if self._build_vtt_file(all_sentences, audio_dir, vtt_path):
+                return True
+            return False
+        except Exception as e:
+            logger.error(f"CambAI VTT creation error: {e}")
+            return False

--- a/lib/classes/tts_engines/presets/cambai_presets.py
+++ b/lib/classes/tts_engines/presets/cambai_presets.py
@@ -1,0 +1,32 @@
+models = {
+    "mars-flash": {
+        "lang": "multi",
+        "repo": None,
+        "sub": None,
+        "voice": None,
+        "voice_id": 147320,
+        "speech_model": "mars-flash",
+        "files": [],
+        "samplerate": 22050
+    },
+    "mars-pro": {
+        "lang": "multi",
+        "repo": None,
+        "sub": None,
+        "voice": None,
+        "voice_id": 147320,
+        "speech_model": "mars-pro",
+        "files": [],
+        "samplerate": 48000
+    },
+    "mars-instruct": {
+        "lang": "multi",
+        "repo": None,
+        "sub": None,
+        "voice": None,
+        "voice_id": 147320,
+        "speech_model": "mars-instruct",
+        "files": [],
+        "samplerate": 22050
+    }
+}

--- a/lib/conf_models.py
+++ b/lib/conf_models.py
@@ -12,7 +12,8 @@ TTS_ENGINES = {
     "FAIRSEQ": "fairseq",
     "GLOWTTS": "glowtts",
     "TACOTRON2": "tacotron",
-    "YOURTTS": "yourtts"
+    "YOURTTS": "yourtts",
+    "CAMBAI": "cambai"
 }
 
 TTS_VOICE_CONVERSION = {
@@ -190,5 +191,18 @@ default_engine_settings = {
         "files": ['config.json', 'model_file.pth'],
         "voices": {"Machinella-5": "female-en-5", "ElectroMale-2": "male-en-2", 'Machinella-4': 'female-pt-4\n', 'ElectroMale-3': 'male-pt-3\n'},
         "rating": {"VRAM": 1, "CPU": 5, "RAM": 1, "Realism": 2}
+    },
+    TTS_ENGINES['CAMBAI']: {
+        "repo": None,
+        "languages": {
+            "eng": "en-us", "spa": "es-es", "fra": "fr-fr", "deu": "de-de",
+            "ita": "it-it", "por": "pt-br", "zho": "zh-cn", "jpn": "ja-jp",
+            "kor": "ko-kr", "ara": "ar-sa", "hin": "hi-in", "rus": "ru-ru",
+            "nld": "nl-nl", "pol": "pl-pl", "tur": "tr-tr", "swe": "sv-se"
+        },
+        "samplerate": 22050,
+        "files": [],
+        "voices": {},
+        "rating": {"VRAM": 0, "CPU": 1, "RAM": 1, "Realism": 5}
     }
 }

--- a/lib/gradio.py
+++ b/lib/gradio.py
@@ -563,7 +563,12 @@ def build_interface(args:dict)->gr.Blocks:
                                         gr_voice_play = gr.Button('▶', elem_id='gr_voice_play', elem_classes=['small-btn'], variant='secondary', interactive=True, visible=False, scale=0, min_width=60)
                                         gr_voice_list = gr.Dropdown(label='Voices', elem_id='gr_voice_list', choices=voice_options, type='value', interactive=True, scale=2)
                                         gr_voice_del_btn = gr.Button('🗑', elem_id='gr_voice_del_btn', elem_classes=['small-btn-red'], variant='secondary', interactive=True, visible=False, scale=0, min_width=60)
-                                with gr.Group(elem_id='gr_group_device', elem_classes=['gr-group']):
+                                gr_group_voice_id = gr.Group(elem_id='gr_group_voice_id', elem_classes=['gr-group'], visible=False)
+                                with gr_group_voice_id:
+                                    gr_voice_id_markdown = gr.Markdown(elem_id='gr_voice_id_markdown', elem_classes=['gr-markdown'], value='Voice ID')
+                                    gr_voice_id = gr.Number(label='Camb AI Voice ID', elem_id='gr_voice_id', value=147320, precision=0, interactive=True)
+                                gr_group_device = gr.Group(elem_id='gr_group_device', elem_classes=['gr-group'])
+                                with gr_group_device:
                                     gr_device_markdown = gr.Markdown(elem_id='gr_device_markdown', elem_classes=['gr-markdown'], value='Processor')
                                     gr_device = gr.Dropdown(label='', elem_id='gr_device', choices=[(k, v['proc']) for k, v in devices.items()], type='value', value=default_device, interactive=True)
                             with gr.Column(elem_id='gr_col_2', elem_classes=['gr-col'], scale=3):
@@ -1284,6 +1289,9 @@ def build_interface(args:dict)->gr.Blocks:
                     session = context.get_session(session_id)
                     if session and session.get('id', False):
                         models = load_engine_presets(session['tts_engine'])
+                        if session['tts_engine'] == TTS_ENGINES['CAMBAI']:
+                            voice_options = []
+                            return gr.update(choices=[], value=None)
                         lang_dir = session['language'] if session['language'] != 'con' else 'con-'  # Bypass Windows CON reserved name
                         file_pattern = "*.wav"
                         eng_options = []
@@ -1356,7 +1364,7 @@ def build_interface(args:dict)->gr.Blocks:
                         else:
                             if voice_options and voice_options[0][1] is not None:
                                 new_voice_path = models[session['fine_tuned']]['voice']
-                                if os.path.exists(new_voice_path) and any(v[1] == new_voice_path for v in voice_options):
+                                if new_voice_path and os.path.exists(new_voice_path) and any(v[1] == new_voice_path for v in voice_options):
                                     session['voice'] = new_voice_path
                                 else:
                                     session['voice'] = voice_options[0][1]
@@ -1415,8 +1423,10 @@ def build_interface(args:dict)->gr.Blocks:
                         ]
                         if session['fine_tuned'] in fine_tuned_options:
                             fine_tuned = session['fine_tuned']
-                        else:
+                        elif default_fine_tuned in fine_tuned_options:
                             fine_tuned = default_fine_tuned
+                        else:
+                            fine_tuned = fine_tuned_options[0] if fine_tuned_options else default_fine_tuned
                         session['fine_tuned'] = fine_tuned
                         return gr.update(choices=fine_tuned_options, value=session['fine_tuned'])
                 except Exception as e:
@@ -1428,6 +1438,11 @@ def build_interface(args:dict)->gr.Blocks:
                 session = context.get_session(session_id)
                 if session and session.get('id', False):
                     session['device'] = selected
+
+            def change_gr_voice_id(value, session_id:str)->None:
+                session = context.get_session(session_id)
+                if session and session.get('id', False):
+                    session['voice_id'] = int(value) if value else 147320
 
             def change_gr_language(selected:str, session_id:str)->tuple:
                 if selected:
@@ -1494,19 +1509,25 @@ def build_interface(args:dict)->gr.Blocks:
                     session['tts_engine'] = engine
                     session['fine_tuned'] = default_fine_tuned
                     session['voice'] = None if engine not in [TTS_ENGINES['XTTSv2'], TTS_ENGINES['BARK']] else session['voice']
+                    is_cloud = engine == TTS_ENGINES['CAMBAI']
+                    visible_voice = not is_cloud
+                    visible_device = not is_cloud
                     visible_bark = False
                     visible_xtts = False
                     if session['tts_engine'] == TTS_ENGINES['XTTSv2']:
                         visible_custom_model = True if session['fine_tuned'] == 'internal' else False
                         visible_xtts = visible_gr_tab_xtts_params
                         return (
-                            gr.update(value=show_rating(session['tts_engine'])), 
+                            gr.update(value=show_rating(session['tts_engine'])),
                             gr.update(visible=visible_xtts),
                             gr.update(visible=False),
                             gr.update(visible=visible_custom_model),
                             update_gr_fine_tuned_list(session_id),
                             gr.update(label=f"Upload {session['tts_engine']} ZIP file (Mandatory: {', '.join(models[default_fine_tuned]['files'])})"),
-                            gr.update(value=f"My {session['tts_engine']} Custom Models")
+                            gr.update(value=f"My {session['tts_engine']} Custom Models"),
+                            gr.update(visible=visible_voice),
+                            gr.update(visible=visible_device),
+                            gr.update(visible=is_cloud)
                         )
                     else:
                         if session['tts_engine'] == TTS_ENGINES['BARK']:
@@ -1514,13 +1535,16 @@ def build_interface(args:dict)->gr.Blocks:
                         return (
                             gr.update(value=show_rating(session['tts_engine'])),
                             gr.update(visible=False),
-                            gr.update(visible=visible_bark), 
+                            gr.update(visible=visible_bark),
                             gr.update(visible=False),
                             update_gr_fine_tuned_list(session_id),
                             gr.update(label=f"*Upload Custom Model not available for {session['tts_engine']}"),
-                            gr.update(value='')
+                            gr.update(value=''),
+                            gr.update(visible=visible_voice),
+                            gr.update(visible=visible_device),
+                            gr.update(visible=is_cloud)
                         )
-                outputs = tuple([gr.update(interactive=False) for _ in range(7)])
+                outputs = tuple([gr.update(interactive=False) for _ in range(10)])
                 return outputs
 
             def change_gr_fine_tuned_list(selected:str, session_id:str)->tuple:
@@ -2054,6 +2078,11 @@ def build_interface(args:dict)->gr.Blocks:
                 inputs=[gr_device, gr_session],
                 outputs=None
             )
+            gr_voice_id.change(
+                fn=change_gr_voice_id,
+                inputs=[gr_voice_id, gr_session],
+                outputs=None
+            )
             gr_language.change(
                 fn=change_gr_language,
                 inputs=[gr_language, gr_session],
@@ -2066,7 +2095,7 @@ def build_interface(args:dict)->gr.Blocks:
             gr_tts_engine_list.change(
                 fn=change_gr_tts_engine_list,
                 inputs=[gr_tts_engine_list, gr_session],
-                outputs=[gr_tts_rating, gr_tab_xtts_params, gr_tab_bark_params, gr_group_custom_model, gr_fine_tuned_list, gr_custom_model_file, gr_custom_model_label]
+                outputs=[gr_tts_rating, gr_tab_xtts_params, gr_tab_bark_params, gr_group_custom_model, gr_fine_tuned_list, gr_custom_model_file, gr_custom_model_label, gr_group_voice_file, gr_group_device, gr_group_voice_id]
             ).then(
                 fn=update_gr_voice_list,
                 inputs=[gr_session],

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,6 @@ torch==2.7.1
 torchaudio==2.7.1
 transformers==4.57.6
 coqui-tts[languages]==0.27.5
+camb-sdk
 ext/py/num2words
 ext/py/demucs


### PR DESCRIPTION
Hi Drew! 👋

I'm Neil from [Camb AI](https://www.camb.ai) - we're the localization engine trusted by brands like the **Premier League**, **Australian Open**, and **NASCAR** for dubbing and voice synthesis. We'd love to be included as a TTS option in this project!

This PR adds **Camb AI** as a new cloud-based TTS engine option for ebook2audiobook.

## What's included

- **New TTS engine class** (`lib/classes/tts_engines/cambai.py`) — integrates the Camb AI TTS API with streaming audio support
- **Preset models** (`lib/classes/tts_engines/presets/cambai_presets.py`) — three model tiers: `mars-flash` (fastest), `mars-pro` (balanced), and `mars-instruct` (highest quality)
- **Voice ID selection** — users can pick from Camb AI's voice library by numeric voice ID
- **Gradio UI updates** — cloud engine support in the GUI, including a voice ID input and appropriate visibility toggling for cloud vs. local engine components
- **Registration & config** — Camb AI registered in the engine index and config models
- **Dependency** — adds the `camb-ai` Python package to `requirements.txt`

### Usage

Set the `CAMB_API_KEY` environment variable and select "cambai" as the TTS engine. Voice IDs can be browsed at [Camb AI's voice library](https://studio.camb.ai).

Happy to address any feedback or make adjustments. Thanks for maintaining such a great project!