### PR TITLE
Fix GPU not detected in full_docker mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,6 +239,19 @@ SML tags available:
                     print(error)
                     sys.exit(1)
         import lib.core as c
+        if args['script_mode'] == FULL_DOCKER:
+            try:
+                import torch
+                if hasattr(torch, 'cuda') and torch.cuda.is_available():
+                    devices['CUDA']['found'] = True
+                if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+                    devices['MPS']['found'] = True
+                if bool(getattr(torch.version, 'hip', None)):
+                    devices['ROCM']['found'] = True
+                if hasattr(torch, 'xpu') and torch.xpu.is_available():
+                    devices['XPU']['found'] = True
+            except Exception:
+                pass
         c.context = c.SessionContext() if c.context is None else c.context
         c.context_tracker = c.SessionTracker() if c.context_tracker is None else c.context_tracker
         c.active_sessions = set() if c.active_sessions is None else c.active_sessions


### PR DESCRIPTION
## Summary

- In `full_docker` mode, GPU devices (CUDA, ROCm, MPS, XPU) are never detected
  at runtime because `DeviceInstaller.detect_device()` is only called in `native`
  and `build_docker` modes.
- This causes `devices['CUDA']['found']` (and other backends) to remain `False`,
  making the app fall back to CPU with the message
  "CUDA not supported by the Torch installed!" — even when `torch.cuda.is_available()`
  returns `True` and the GPU is fully functional.
- The fix adds a lightweight runtime check in `app.py` after `import lib.core`,
  using the same `torch` APIs the rest of the codebase already relies on.

## Root cause

`app.py` line 231:

```python
if args['script_mode'] in [NATIVE, BUILD_DOCKER]:
    ...  # DeviceInstaller runs here
```

In `full_docker` mode this block is skipped entirely, so `devices[...]['found']`
flags are never set to `True`. Later, `lib/core.py` checks these flags (line 2764)
and switches to CPU when they are `False`.

## How to verify

```bash
docker compose --profile gpu up -d
docker compose --profile gpu logs | grep -i "using cuda"
# Should print "Using CUDA" instead of "CUDA not supported by the Torch installed!"
```

## Test plan

- [x] Built Docker image with CUDA support
- [x] Verified `torch.cuda.is_available()` returns `True` inside container
- [x] Verified logs show "Using CUDA" instead of CPU fallback
- [x] Successfully ran a TTS conversion using GPU