### PR TITLE
Add a [chapter] sml tag (Concept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ https://github.com/user-attachments/assets/81c4baad-117e-4db5-ac86-efc2b7fea921
 - `[break]` — silence (random range **0.3–0.6 sec.**)
 - `[pause]` — silence (random range **1.0–1.6 sec.**)
 - `[pause:N]` — fixed pause (**N sec.**)
+- `[chapter]` — chapter marker
 - `[voice:/path/to/voice/file]...[/voice]` — switch voice from default or selected voice from GUI/CLI
 
 **Check our other repo dedicated to add SML automatically in your ebook -> [E2A-SML](https://github.com/DrewThomasson/E2A-SML)**

--- a/lib/core.py
+++ b/lib/core.py
@@ -1036,7 +1036,11 @@ INTO A NEW TRAINING MODEL. YOU CAN IMPROVE IT OR ASK TO A TRAINING MODEL EXPERT.
                         error = f'Error extracting content from document #{doc_idx + 1}; aborting conversion to avoid partial output.'
                         show_alert(session_id, {"type": "warning", "msg": error})
                         return []
-                    blocks.append(text)
+                    parts = re.split(r'\[(?i)chapter\]', text)
+                    for part in parts:
+                        part = part.strip()
+                        if part:
+                            blocks.append(part)
             if len(blocks) == 0:
                 error = 'No blocks found! possible reason: file corrupted or need to convert images to text with OCR'
                 print(error)
@@ -2310,7 +2314,7 @@ def convert_chapters2audio(session_id:str)->bool:
                     chapter_audio_file = os.path.join(session['chapters_dir'], f'{x}.{default_audio_proc_format}')
                     save_json_blocks(session_id, 'blocks_current')
                     last_save_time = time.monotonic()
-                    if not combine_audio_sentences(session_id, chapter_audio_file, x, len(sentences)):
+                    if not combine_audio_sentences(session_id, chapter_audio_file, x, sentences):
                         show_alert(session_id, {'type': 'warning', 'msg': 'combine_audio_sentences() failed!'})
                         session['blocks_current'] = blocks_current
                         return False
@@ -2324,7 +2328,7 @@ def convert_chapters2audio(session_id:str)->bool:
         exception_alert(session_id, f'convert_chapters2audio() error: {e}')
         return False
 
-def combine_audio_sentences(session_id:str, file:str, block_idx:int, sentence_count:int)->bool:
+def combine_audio_sentences(session_id:str, file:str, block_idx:int, sentences:list)->bool:
     try:
         session = context.get_session(session_id)
         if not session or not session.get('id', False):
@@ -2335,12 +2339,18 @@ def combine_audio_sentences(session_id:str, file:str, block_idx:int, sentence_co
         ext = f'.{default_audio_proc_format}'
         missing = []
         selected_files = []
-        for i in range(sentence_count):
+        for i, sentence in enumerate(sentences):
             path = os.path.join(block_dir, f'{i}{ext}')
-            if os.path.exists(path):
-                selected_files.append(path)
-            else:
-                missing.append(i)
+            sentence = sentence.strip()
+            if any(c.isalnum() for c in sentence):
+                is_sml = bool(SML_TAG_PATTERN.fullmatch(sentence))
+                if (not is_sml) or (i == len(sentences) - 1):
+                    if os.path.exists(path):
+                        selected_files.append(path)
+                    else:
+                        missing.append(i)
+                elif os.path.exists(path):
+                    selected_files.append(path)
         if missing:
             error = f'Missing sentence files in block {block_idx}: {missing}'
             print(error)

--- a/lib/core.py
+++ b/lib/core.py
@@ -1036,11 +1036,26 @@ INTO A NEW TRAINING MODEL. YOU CAN IMPROVE IT OR ASK TO A TRAINING MODEL EXPERT.
                         error = f'Error extracting content from document #{doc_idx + 1}; aborting conversion to avoid partial output.'
                         show_alert(session_id, {"type": "warning", "msg": error})
                         return []
-                    parts = re.split(r'\[(?i)chapter\]', text)
-                    for part in parts:
-                        part = part.strip()
-                        if part:
-                            blocks.append(part)
+                    if re.search(r'\[/chapter\]', text, flags=re.IGNORECASE):
+                        matches = re.finditer(r'\[chapter(?:[:=]([^\]]+))?\](.*?)\[/chapter\]', text, flags=re.DOTALL | re.IGNORECASE)
+                        for m in matches:
+                            title = (m.group(1) or '').strip()
+                            content = m.group(2).strip()
+                            if title:
+                                content = f"{title}. {content}"
+                            if content:
+                                blocks.append(content)
+                    else:
+                        parts = re.split(r'\[chapter(?:[:=]([^\]]+))?\]', text, flags=re.IGNORECASE)
+                        if parts[0].strip():
+                            blocks.append(parts[0].strip())
+                        for idx in range(1, len(parts), 2):
+                            title = parts[idx]
+                            content = parts[idx+1].strip() if idx+1 < len(parts) else ""
+                            if title and title.strip():
+                                content = f"{title.strip()}. {content}"
+                            if content:
+                                blocks.append(content)
             if len(blocks) == 0:
                 error = 'No blocks found! possible reason: file corrupted or need to convert images to text with OCR'
                 print(error)

--- a/tools/workflow-testing/sml-test.txt
+++ b/tools/workflow-testing/sml-test.txt
@@ -1,5 +1,20 @@
+[chapter:Introduction]
 Hello there, and welcome to this audio test. [break] My name is David Attenborough, and I will be your guide through this remarkable demonstration. [pause] In the natural world, silence speaks volumes. [pause:2] But now, let us hear from someone else entirely.
+[/chapter]
+
+[chapter:McGonagall's Review]
 [voice:voices/eng/elder/female/ProfessorMcgonagall.wav] Ah yes, quite right. I am Professor McGonagall, and I must say, this SML tag system is rather impressive. [break] One must appreciate precision in all things, including timed pauses. [pause] Now pay close attention, because we are about to hear from yet another voice. [/voice]
+[/chapter]
+
+[chapter:ASMR Experience]
 [voice:voices/eng/elder/male/JohnButlerASMR.wav] Hey there, welcome in. [break] Just take a deep breath, and relax. [pause:1] Everything is going to be just fine. [pause] I hope that felt as smooth as it sounded. [/voice]
+[/chapter]
+
+[chapter:The Migration]
 [voice:voices/eng/elder/male/DavidAttenborough.wav] And so we return, full circle, to where we began. [break] The great migration of voices, across this humble text file, is complete. [pause:2] Extraordinary. [/voice]
+[/chapter]
+
+[chapter]
 And that, my friend, is the default voice once more, wrapping up this complete SML tag test. [break] Every tag has been exercised. [pause] Test complete.
+	
+[/chapter]


### PR DESCRIPTION
Seem to work on my end, 

Add manual [CHAPTER] tag splitting and fix audio stitching crash

But in doing so I had to add a fix for a bug where the chapter might start with "." so its skipped but that ... crashed it?

AI Explanation

```
Add manual [CHAPTER] tag splitting and fix audio stitching crash

Tested and appears to work well on my end! Added the ability to manually cut chapters using a [CHAPTER] tag in the text.

But in doing so, I had to fix a pre-existing bug where a chapter block might start or end with just a . (or other stranded punctuation).

Because a solitary . has no letters or numbers, the audio generator correctly skipped rendering a .flac file for it. However, the 

combine_audio_sentences()
 function blindly expected a file to exist for every single line and crashed when it couldn't find the audio file. I synced up the logic so the audio stitcher now properly ignores blank/punctuation-only lines just like the generator does.


```

