### PR TITLE
fix: remove unreachable `return False` in SessionTracker.start_session()

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -119,7 +119,6 @@ class SessionTracker:
             session['status'] = status_tags['READY']
             #self.blocks_autosave.register(session_id)
             return True
-        return False
 
     def end_session(self, session_id:str, socket_hash:str)->None:
         #self.blocks_autosave.unregister(session_id)


### PR DESCRIPTION
## Summary

Removes the unreachable `return False` statement on line 122 of `lib/core.py` in the `SessionTracker.start_session()` method.

## Problem

```python
def start_session(self, session_id:str)->bool:
    with self.lock:
        session = context.get_session(session_id)
        session['status'] = status_tags['READY']
        return True
    return False   # unreachable — control never reaches here
```

The `return True` inside the `with` block always exits the function before the block ends. The `return False` line after the `with` statement is therefore dead code and is never executed.

## Fix

Remove the unreachable line. If returning `False` on exception was ever the intent, that would require a `try/except` block — but the current code never raises inside this path intentionally.

Closes #1774