### PR TITLE
fix: resume conversion after power cut / session drop on Windows

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -2155,7 +2155,12 @@ def convert_chapters2audio(session_id:str)->bool:
         if os.path.isdir(block_dir):
             shutil.rmtree(block_dir)
 
-    def _check_block_sentences(block_id:str, sentences:list)->set:
+    def _check_block_sentences(block_id:str, x:int, sentences:list)->set:
+        # If the final combined chapter audio already exists, treat block as complete
+        # even if individual sentence files were lost (e.g. after a power cut)
+        chapter_audio_file = os.path.join(session['chapters_dir'], f'{x}.{default_audio_proc_format}')
+        if os.path.exists(chapter_audio_file):
+            return set()
         block_dir = os.path.join(session['sentences_dir'], block_id)
         missing = set()
         for j, sentence in enumerate(sentences):
@@ -2240,14 +2245,18 @@ def convert_chapters2audio(session_id:str)->bool:
                 hash_ref = block_hash(block_ref) if block_ref else None
                 block_changed = bool(prev_blocks) and hash_ref != current_hash
                 missing_sentences = set()
-                if x < block_resume and not block_changed:
-                    chapter_audio_file = os.path.join(session['chapters_dir'], f'{block_id}.{default_audio_proc_format}')
-                    if not os.path.exists(chapter_audio_file):
-                        show_alert(session_id, {'type': 'warning', 'msg': f'Block {x} chapter audio missing, reconverting entire block…'})
-                        _reset_chapter_file(block_id)
-                        start_sentence = 0
-                    else:
-                        missing_sentences = _check_block_sentences(block_id, sentences)
+                if not block_changed:
+                    chapter_audio_file = os.path.join(session['chapters_dir'], f'{x}.{default_audio_proc_format}')
+                    if os.path.exists(chapter_audio_file):
+                        # Chapter .flac already exists and block is unchanged — skip entirely.
+                        # This handles resume after power cuts where sentence files are gone
+                        # but the combined chapter audio survived.
+                        print(f'Chapter {ch_num} (block {x}) — chapter audio exists, skipping')
+                        global_sent += _count_sentences(sentences)
+                        t.update(len(sentences))
+                        continue
+                    elif x < block_resume:
+                        missing_sentences = _check_block_sentences(block_id, x, sentences)
                         if not missing_sentences:
                             print(f'Chapter {ch_num} (block {x}) — has all sentences')
                             global_sent += _count_sentences(sentences)

--- a/lib/core.py
+++ b/lib/core.py
@@ -2147,8 +2147,8 @@ def block_hash(block: dict) -> str:
 
 def convert_chapters2audio(session_id:str)->bool:
 
-    def _reset_chapter_file(block_id:str)->None:
-        ch_file = os.path.join(session['chapters_dir'], f'{block_id}.{default_audio_proc_format}')
+    def _reset_chapter_file(block_id:str, x:int)->None:
+        ch_file = os.path.join(session['chapters_dir'], f'{x}.{default_audio_proc_format}')
         if os.path.exists(ch_file):
             os.unlink(ch_file)
         block_dir = os.path.join(session['sentences_dir'], block_id)
@@ -2263,11 +2263,13 @@ def convert_chapters2audio(session_id:str)->bool:
                             t.update(len(sentences))
                             continue
                         show_alert(session_id, {'type': 'warning', 'msg': f'Block {x} has {len(missing_sentences)} missing audio files, reconverting…'})
-                        _reset_chapter_file(block_id)
+                        _reset_chapter_file(block_id, x)
+                        start_sentence = 0
+                    else:
                         start_sentence = 0
                 elif block_changed and x <= block_resume:
                     show_alert(session_id, {'type': 'info', 'msg': f'Chapter {ch_num} (block {x}) — changed, reconverting'})
-                    _reset_chapter_file(block_id)
+                    _reset_chapter_file(block_id, x)
                     start_sentence = 0
                 elif x == block_resume:
                     if sentence_resume == 0:
@@ -2323,7 +2325,7 @@ def convert_chapters2audio(session_id:str)->bool:
                 show_alert(session_id, {'type': 'info', 'msg': f'End of Chapter {ch_num} (block {x})'})
                 if converted or block_changed or missing_sentences:
                     show_alert(session_id, {'type': 'info', 'msg': f'Combining chapter {ch_num} (block {x}) to audio, sentence {sent_start} to {sent_end}'})
-                    chapter_audio_file = os.path.join(session['chapters_dir'], f'{block_id}.{default_audio_proc_format}')
+                    chapter_audio_file = os.path.join(session['chapters_dir'], f'{x}.{default_audio_proc_format}')
                     save_json_blocks(session_id, 'blocks_current')
                     last_save_time = time.monotonic()
                     if not combine_audio_sentences(session_id, chapter_audio_file, block_id, len(sentences)):


### PR DESCRIPTION
## Problem

On Windows, if a conversion is interrupted (power cut, OS shutdown, session expiry), restarting and resuming always re-renders from block 0 — even when most chapter `.flac` files already exist in the `chapters/` temp folder.

Two root causes:

1. **`blocks_saved` JSON is never written on a fresh run** — it is only saved after a fully clean conversion completes. On resume, `block_ref` is always `None`, so `hash_ref` is always `None`, so `block_changed = True` for every block, and every chapter reconverts regardless.

2. **Skip logic was gated on `x < block_resume`** — even when `block_changed=False`, blocks with index >= `block_resume` were never checked for an existing chapter `.flac`, so they were always re-rendered.

Additionally, on Windows the `sentences/` temp folder (individual per-sentence audio files) gets cleaned up by the OS on hard shutdown, while the combined `chapters/*.flac` files survive. The old code only checked for sentence files, so every chapter appeared incomplete.

## Fix

- **`_check_block_sentences`**: returns empty set (no missing sentences) immediately if the combined chapter `.flac` already exists — handles the case where sentence temp files were wiped by a hard shutdown but the chapter audio survived.

- **`convert_chapters2audio` resume logic**: when `block_changed=False`, check for an existing chapter `.flac` first and skip the block entirely, regardless of `block_resume` index. This means any chapter that was fully rendered in a previous run is never re-rendered, even if `block_resume` points to an earlier block.

- **`utils.py`**: force `amp_dtype = torch.float16` for Ampere GPUs (CC >= 8) on Windows to fix `Got unsupported ScalarType BFloat16` / CUDA to numpy crash on RTX 30xx/40xx series.

## Testing

Verified on Windows 11 + RTX 4060 (CUDA) converting a 13,153-sentence Spanish epub with XTTSv2. After a hard power cut at ~90% completion:
- All 27 completed chapter `.flac` files were correctly skipped on resume
- Conversion resumed from the interrupted chapter without re-rendering anything
- Final audiobook output was correct
