### PR TITLE
fix: build prev_blocks before voice conversion to prevent false block changed on resume

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -2182,6 +2182,7 @@ def convert_chapters2audio(session_id:str)->bool:
         sentence_resume = blocks_current['sentence_resume']
         if session['cancellation_requested']:
             return False
+        prev_blocks = {b['id']: b for b in (session.get('blocks_saved') or {}).get('blocks', [])}
         xtts_languages = default_engine_settings[TTS_ENGINES['XTTSv2']].get('languages', {})
         if session['language'] != 'eng' and session['language'] in xtts_languages:
             voice_cache = {}
@@ -2201,7 +2202,6 @@ def convert_chapters2audio(session_id:str)->bool:
                 if new_voice != old_voice:
                     block['voice'] = new_voice
             session['blocks_current'] = blocks_current
-        prev_blocks = {b['id']: b for b in (session.get('blocks_saved') or {}).get('blocks', [])}
         total_chapters = sum(1 for b in blocks if b['keep'] and b['text'].strip())
         if total_chapters == 0:
             show_alert(session_id, {'type': 'warning', 'msg': 'No chapters found!'})


### PR DESCRIPTION
Fixes #1789

For non-English languages, set_voice() transforms the block voice path to an internal session path before the hash comparison. This caused block_changed=True on every resume even when nothing had actually changed, forcing all blocks to be reconverted from scratch.

Fix: move prev_blocks construction to before the voice conversion loop, so both current_hash and hash_ref are computed with the original voice path.