### PR TITLE
fix: append [break] token to preceding text element to prevent sentence-start distortion

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -1202,7 +1202,11 @@ def filter_blocks(session_id:str, idx:int, doc:EpubHtml, stanza_nlp:Pipeline, is
                     text_list.append(payload.strip())
                 elif typ in ('break', 'pause'):
                     if prev_typ != typ:
-                        text_list.append(sml_token(typ))
+                        token = sml_token(typ)
+                        if text_list and text_list[-1] not in {v['static'] for v in TTS_SML.values() if 'static' in v}:
+                            text_list[-1] = text_list[-1] + token
+                        else:
+                            text_list.append(token)
                 elif typ == 'table':
                     table = payload
                     if table in handled_tables:


### PR DESCRIPTION
Fixes #1791

[break] tokens were inserted as separate elements between text chunks during HTML parsing. After sentence splitting, they ended up at the beginning of the following sentence. XTTSv2 then processed [break] as the first token of a new inference call with no prior speech context, causing distortion or hallucination on the first word.

Fix: append the [break] token directly to the last text element in text_list (if it is not itself a SML token), so the break is processed at the end of the preceding inference call instead.

Before: "[break]Dann begann sie..."
After:  "Dann begann sie..."  (break appended to previous sentence)