### PR TITLE
fix: force FP16 on Blackwell GPUs (RTX 50xx) to prevent BFloat16 not supported error

### DIFF
--- a/lib/classes/tts_engines/common/utils.py
+++ b/lib/classes/tts_engines/common/utils.py
@@ -261,6 +261,11 @@ class TTSUtils:
             if is_jetson or is_rocm:
                 # Jetson + ROCm → FP16 (BF16 unstable / slow on these)
                 amp_dtype = torch.float16
+            elif cc_major >= 12:
+                # Blackwell (RTX 50xx) — hardware supports BF16/FP8/FP4,
+                # but coqui-tts XTTSv2 does not yet support BFloat16.
+                # Fall back to FP16 until coqui-tts adds BF16 support.
+                amp_dtype = torch.float16
             elif cc_major >= 8:
                 # Ampere+ (RTX 30xx/40xx, A/H/L) — full tensor cores, BF16 available
                 use_bf16 = False


### PR DESCRIPTION
Fixes #1793

Blackwell GPUs (RTX 50xx, compute capability >= 12) are detected as Ampere+ (cc_major >= 8) and receive BFloat16 as amp_dtype. However, coqui-tts XTTSv2 does not support BFloat16, causing:

    "Got unsupported ScalarType BFloat16"

Fix: add an explicit check for cc_major >= 12 before the Ampere+ branch and force FP16 for Blackwell. Ampere/Ada (RTX 30xx/40xx) are unaffected and retain their BF16 path.

Tested on: RTX 5060 (8GB), Windows 10, CUDA 13.1