### PR TITLE
Fix crash when mwt processor is unavailable in Stanza

### DIFF
--- a/lib/core.py
+++ b/lib/core.py
@@ -1011,7 +1011,16 @@ INTO A NEW TRAINING MODEL. YOU CAN IMPROVE IT OR ASK TO A TRAINING MODEL EXPERT.
                             (session['device'] == devices['XPU']['proc'] and devices['XPU']['found']) or
                             (session['device'] == devices['JETSON']['proc'] and devices['JETSON']['found'])
                         ) else False
-                        stanza_nlp = stanza.Pipeline(session['language_iso1'], processors='tokenize,ner,mwt', use_gpu=use_gpu, download_method=DownloadMethod.REUSE_RESOURCES, dir=os.getenv('STANZA_RESOURCES_DIR'))
+                        # only use mwt if the language supports it
+                        stanza_lang = session['language_iso1']
+                        stanza_has_mwt = False
+                        try:
+                            stanza_resources = stanza.resources.common.load_resources_json(os.getenv('STANZA_RESOURCES_DIR', stanza.resources.common.DEFAULT_MODEL_DIR))
+                            stanza_has_mwt = 'mwt' in stanza_resources.get(stanza_lang, {})
+                        except Exception:
+                            pass
+                        stanza_processors = 'tokenize,mwt,ner' if stanza_has_mwt else 'tokenize,ner'
+                        stanza_nlp = stanza.Pipeline(stanza_lang, processors=stanza_processors, use_gpu=use_gpu, download_method=DownloadMethod.REUSE_RESOURCES, dir=os.getenv('STANZA_RESOURCES_DIR'))
                         if stanza_nlp:
                             session['stanza_cache'] = stanza_model
                             loaded_tts[stanza_model] = stanza_nlp


### PR DESCRIPTION
Some languages (for example: Swedish) cause the pipeline to fail because the mwt processor is requested even though it is not available in Stanza's resources for those languages.

This PR updates the pipeline initialization to check Stanza’s available resources for the target language and only include the mwt processor when it is supported.

As a result, the pipeline no longer crashes for languages without MWT support, while remaining fully compatible with languages that do provide it.

Error fixed

```
ERROR: Cannot load model from D:\ebook2audiobook\models\stanza\sv\mwt\default.pt
Stanza model initialization error: Processor mwt is not known for language sv.
If you have created your own model, please specify the mwt_model_path parameter when creating the pipeline.
get_blocks() or save_json_blocks() failed! {}
```
<img width="1320" height="280" alt="bild" src="https://github.com/user-attachments/assets/348dea96-ba4b-4992-958b-c93e86db6644" />
