### PR TITLE
fix: Windows install fails with "13.0 was unexpected at this time" on CUDA 13.0

### DIFF
--- a/ebook2audiobook.cmd
+++ b/ebook2audiobook.cmd
@@ -618,31 +618,29 @@ for /f "delims=" %%i in ('where.exe python 2^>nul') do (
         )
     )
 )
-if "%CURRENT_ENV%"=="" (
-    if not exist "%SAFE_SCRIPT_DIR%\%PYTHON_ENV%" (
-        echo Creating ./python_env version %PYTHON_VERSION%…
-        call "%CONDA_HOME%\Scripts\activate.bat"
-        call conda update -n base -c conda-forge conda -y
-        call conda update --all -y
-        call conda clean --index-cache -y
-        call conda clean --packages --tarballs -y
-		call conda create --prefix "%SAFE_SCRIPT_DIR%\%PYTHON_ENV%" python=%PYTHON_VERSION% pip -y
-        ::call conda activate base
-        call conda activate "%SAFE_SCRIPT_DIR%\%PYTHON_ENV%"
-		call :check_device_info %SCRIPT_MODE%
-        if errorlevel 1 goto :failed
-		echo -------------------------------- %DEVICE_INFO_STR%
-		call :install_device_packages "%DEVICE_INFO_STR%"
-		if errorlevel 1 goto :failed
-        call :install_python_packages
-        if errorlevel 1 goto :failed
-		call conda deactivate >nul && call conda deactivate >nul
-    )
-) else (
-    echo Current python virtual environment detected: %CURRENT_ENV%. 
+if not "%CURRENT_ENV%"=="" (
+    echo Current python virtual environment detected: %CURRENT_ENV%.
     echo =============== This script runs with its own virtual env and must be out of any other virtual environment when it's launched.
     exit /b 2
 )
+if exist "%SAFE_SCRIPT_DIR%\%PYTHON_ENV%" exit /b 0
+echo Creating ./python_env version %PYTHON_VERSION%…
+call "%CONDA_HOME%\Scripts\activate.bat"
+call conda update -n base -c conda-forge conda -y
+call conda update --all -y
+call conda clean --index-cache -y
+call conda clean --packages --tarballs -y
+call conda create --prefix "%SAFE_SCRIPT_DIR%\%PYTHON_ENV%" python=%PYTHON_VERSION% pip -y
+call conda activate "%SAFE_SCRIPT_DIR%\%PYTHON_ENV%"
+call :check_device_info %SCRIPT_MODE%
+if errorlevel 1 goto :failed
+echo -------------------------------- %DEVICE_INFO_STR%
+set "DEVICE_INFO_PASS=%DEVICE_INFO_STR%"
+call :install_device_packages
+if errorlevel 1 goto :failed
+call :install_python_packages
+if errorlevel 1 goto :failed
+call conda deactivate >nul && call conda deactivate >nul
 exit /b 0
 
 :check_wsl
@@ -728,7 +726,7 @@ exit /b 0
 :check_device_info
 set "ARG=%~1"
 for /f "delims=" %%I in ('python -c "import sys; from lib.classes.device_installer import DeviceInstaller as D; r=D().check_device_info(sys.argv[1]); print(r if r else '')" "%ARG%"') do set "DEVICE_INFO_STR=%%I"
-if "%DEVICE_INFO_STR%"=="" (
+if not defined DEVICE_INFO_STR (
 	echo DEVICE_INFO_STR is empty
 	exit /b 1
 )
@@ -753,9 +751,7 @@ echo Installing python dependencies…
 exit /b %errorlevel%
 
 :install_device_packages
-set "arg=%~1"
-"%PS_EXE%" %PS_ARGS% -Command ^
-"python -c \"import sys; from lib.classes.device_installer import DeviceInstaller; device = DeviceInstaller(); sys.exit(device.install_device_packages(r'%arg%'))\""
+python -c "import sys, os; from lib.classes.device_installer import DeviceInstaller; device = DeviceInstaller(); sys.exit(device.install_device_packages(os.environ.get('DEVICE_INFO_PASS','')))"
 exit /b %errorlevel%
 
 :check_sitecustomized
@@ -966,6 +962,7 @@ if defined arguments.help (
             if errorlevel 1 goto :failed
             call :check_device_info %SCRIPT_MODE%
             if errorlevel 1 goto :failed
+			set "DEVICE_INFO_PASS=!DEVICE_INFO_STR!"
 			call :install_device_packages
             if "!DEVICE_TAG!"=="" (
                 call :json_get tag


### PR DESCRIPTION
Issue: 
On Windows with CUDA 13.0, running ebook2audiobook.cmd fails immediately after conda environment creation with:
`13.0 was unexpected at this time.`

Initial cause:
On Windows with CUDA 13.0, `check_device_info` stores a JSON string containing `"CUDA 13.0 detected via nvidia-smi"` into `DEVICE_INFO_STR`. The code row 731: `if "%DEVICE_INFO_STR%"==""` expands the JSON inline, causing CMD to choke on the bare `13.0` token with "13.0 was unexpected at this time."

Initial fix:
Replace with `if not defined DEVICE_INFO_STR` which checks existence without ever expanding the variable's value.

Initial result:
Fixed the installer from crashing and it instead continued by installing Miniforge. However, uncovered the underlying issue of `device_info_str=` being empty as seen in the following error:
```
install_device_packages() error: json.loads() could not decode device_info_str=
=============== ebook2audiobook is not correctly installed.
```

Root causes:
1. In `:check_conda`, the calls to `:check_device_info` and `:install_device_packages` were inside nested `if (...) (...)` parenthesis blocks. CMD pre-expands all `%variables%` at parse time within these blocks, so `%DEVICE_INFO_STR%` was always empty string by the time the lines executed, regardless of what `:check_device_info` had set.
2. Passing the JSON string as a command-line argument to `:install_device_packages` caused CMD to corrupt the internal double quotes of the JSON, resulting in a parse error in Python.

Fixes:

- Flattened the nested if blocks in `:check_conda` using early `exit /b` and `goto`-free logic so variables are expanded at execution time
- Changed `:install_device_packages` to receive the JSON via `DEVICE_INFO_PASS` environment variable instead of a CLI argument, so CMD's argument parser never touches the JSON content
- Applied the same `DEVICE_INFO_PASS` pattern to the `BUILD_DOCKER` call site for consistency

Result:
The `device_info_str` is correctly set and the installation proceeds successfully.

<img width="1258" height="274" alt="bild" src="https://github.com/user-attachments/assets/9230229f-2247-464d-81a6-986b232e05a3" />

Tested on: Windows 10, NVIDIA GeForce GTX 1070, CUDA 13.0 (driver-only, nvidia-smi reported). May need further testing on other configurations.