### PR TITLE
Skip voice conversion when voice file matches target language

### DIFF
--- a/lib/classes/tts_engines/common/utils.py
+++ b/lib/classes/tts_engines/common/utils.py
@@ -464,9 +464,13 @@ class TTSUtils:
             import numpy as np
             from huggingface_hub import hf_hub_download
             voice_parts = Path(current_voice).parts
-            if (self.language in voice_parts or speaker in default_engine_settings[TTS_ENGINES['BARK']]['voices'] or self.language == 'eng'):
-                if os.path.exists(current_voice):
-                    return current_voice
+            # Skip conversion if the voice already matches the target language
+            lang_iso1 = getattr(self, 'language_iso1', '')
+            if (self.language in voice_parts or
+                lang_iso1 in voice_parts or
+                speaker in default_engine_settings[TTS_ENGINES['BARK']]['voices'] or
+                self.language == 'eng'):
+                return current_voice
             xtts = TTS_ENGINES['XTTS']
             if self.language in default_engine_settings[xtts].get('languages', {}):
                 default_text_file = os.path.join(voices_dir, self.language, 'default.txt')


### PR DESCRIPTION
## Problem

When using a voice file that's already in the target language directory (e.g., `voices/spa/.../voice.wav` with `--language spa`), `_check_xtts_builtin_speakers()` still runs the expensive voice conversion and normalize on every sentence. This causes a ~10x slowdown for non-English audiobooks using native voices.

## Root cause

The existing language check has two issues:

1. **`os.path.exists()` gate**: the early return was nested inside `if os.path.exists(current_voice)`, which fails when the working directory doesn't match the relative voice path — so the skip never fires.
2. **Missing ISO-639-1 fallback**: some voice directories use the two-letter code (`es`) rather than three-letter (`spa`). The check only tested `self.language` (ISO-639-3).

## Fix

- Add `lang_iso1` check so both `spa` and `es` in the voice path trigger the skip
- Remove the nested `os.path.exists()` gate so the early return works regardless of CWD
- 7 lines changed, 3 removed — minimal, backward-compatible

## Reproduction

```bash
# Place any Spanish .wav voice in voices/spa/adult/male/
# Run with --language spa --tts_engine xtts --voice voices/spa/adult/male/MyVoice.wav
# Without fix: "Converting builtin eng voice to spa" on every sentence
# With fix: conversion skipped, voice used directly
```