### PR TITLE
Make UniDic dictionary download optional (skip for non-Japanese languages)

### DIFF
--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -1231,14 +1231,12 @@ class DeviceInstaller():
         unidic_path = unidic.DICDIR
         dicrc = os.path.join(unidic_path, 'dicrc')
         if not os.path.exists(dicrc) or os.path.getsize(dicrc) == 0:
-            try:
-                error = 'UniDic dictionary not found or incomplete. Downloading now…'
-                print(error)
-                subprocess.run(['python', '-m', 'unidic', 'download'], check=True)
-            except (subprocess.CalledProcessError, ConnectionError, OSError) as e:
-                error = f'Failed to download UniDic dictionary. Error: {e}. Unable to continue without UniDic. Exiting…'
-                raise SystemExit(error)
-                return 1
+            msg = (
+                'WARNING: UniDic dictionary not found. '
+                'UniDic is only required for Japanese TTS. '
+                'If you need Japanese support, run: python3 -m unidic download'
+            )
+            print(msg)
         return 0
           
     def install_device_packages(self, device_info_str:str)->int:


### PR DESCRIPTION
## Summary

- **UniDic is only needed for Japanese TTS** — the ~500MB dictionary is irrelevant for English, Spanish, and all other languages
- **Current behavior downloads UniDic on every startup**, blocking the app for several minutes on slow connections, even when the user never uses Japanese
- **Fix replaces the fatal download-or-exit with a warning** — `check_dictionary()` now prints a notice and continues normally when UniDic is missing
- **Japanese users can still install UniDic manually** by running `python3 -m unidic download`
- The Japanese phonemizer in TTS already handles missing UniDic gracefully (via the `RuntimeError` catch in its `__init__.py`), so this change is safe

## Changes

In `lib/classes/device_installer.py`, the `check_dictionary()` method no longer attempts to download UniDic or raise `SystemExit` when the dictionary is missing. Instead it prints a warning and returns 0.

## Test plan

- [ ] Start the app with a non-Japanese language (e.g. English or Spanish) — should start without delay and print the UniDic warning
- [ ] Start the app with Japanese TTS after running `python3 -m unidic download` — should work as before
- [ ] Start the app with Japanese TTS without UniDic installed — should print warning at startup; TTS engine handles the missing dictionary at synthesis time