### PR TITLE
feat: content-addressed TTS cache + machine-readable progress/ETA (fast incremental re-renders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ https://github.com/user-attachments/assets/81c4baad-117e-4db5-ac86-efc2b7fea921
   - [Run Locally](#instructions)
     - [Launching Gradio Web Interface](#instructions)
     - [Basic Headless Usage](#basic-usage)
+    - [Incremental re-renders & progress tracking](#incremental-re-renders--progress-tracking)
     - [Headless Custom XTTS Model Usage](#example-of-custom-model-zip-upload)
     - [Help command output](#help-command-output)
   - [Run Remotely](#run-remotely)
@@ -114,6 +115,8 @@ https://github.com/user-attachments/assets/81c4baad-117e-4db5-ac86-efc2b7fea921
 - 🧩 **Optional custom model** using your own trained model (XTTSv2, VITS, FAIRSEQ, PIPER, others on request)
 - 🎛️ **Fine-tuned preset models** trained by the E2A Team<br/>
      <i>(Contact us if you need additional fine-tuned models, or if you’d like to share yours to the official preset list)</i>
+- ⚡ **Incremental re-renders** — a content-addressed cache reuses unchanged audio, so editing your book only re-renders the sentences that changed ([see below](#incremental-re-renders--progress-tracking))
+- 📈 **Machine-readable progress + ETA** — every run writes a `progress.json` with live status, percent, and an accurate ETA ([see below](#incremental-re-renders--progress-tracking))
 
 
 ##  Hardware Requirements
@@ -218,6 +221,65 @@ to let the web page reconnect to the new connection socket.**
   - **[--language]**: Language code in ISO-639-3 (i.e.: ita for italian, eng for english, deu for german...).<br>
     Default language is eng and --language is optional for default language set in ./lib/lang.py.<br>
     The ISO-639-1 2 letters codes are also supported.
+
+
+### Incremental re-renders & progress tracking
+
+When you proof a book and make small edits, you don't want to re-render the
+whole audiobook every time. ebook2audiobook caches each rendered sentence by its
+**content** and reuses it on the next run, and it writes a machine-readable
+progress file so you (or a script) can watch status and ETA.
+
+#### Faster re-renders (content cache)
+
+Every rendered sentence is stored under `tmp/tts_cache/<hash>.flac`, keyed by the
+sentence text + voice + engine + language + parameters. On the next run a cached
+sentence is reused instantly (no inference); only sentences that actually changed
+are re-rendered. This works **across separate runs** and even without `--session`,
+so editing one paragraph and re-running re-renders just that paragraph.
+
+```bash
+# default: cache on. Edit your ebook, run again — only changed sentences render.
+./ebook2audiobook.command --headless --ebook book.epub --language eng --voice voices/eng/.../Voice.wav
+
+EBOOK2AUDIO_TTS_CACHE=0   # set this to disable the cache
+EBOOK2AUDIO_CACHE_DEBUG=1 # set this to print each sentence's cache key
+rm -rf tmp/tts_cache      # clear the cache
+```
+
+The cache key includes the voice and TTS parameters, so changing the voice,
+engine, fine-tuned model, or a setting like temperature correctly invalidates it.
+
+#### Live progress + ETA (`progress.json`)
+
+Each run writes a JSON snapshot you can read at any time — independent of the
+console, so it works even when output is redirected or running in the background:
+
+- `tmp/progress/latest.json` — the most recent run
+- `tmp/progress/<session-id>.json` — one file per run (handy for parallel runs)
+
+The startup log also prints `PROGRESS_JSON: <path>`.
+
+```bash
+cat tmp/progress/latest.json
+```
+
+```jsonc
+{
+  "status": "running",                 // running | done | error | cancelled
+  "totals":   { "sentences": 412, "to_render": 7, "cached_at_start": 405 },
+  "progress": { "percent": 71.4, "done": 294, "rendered": 4, "reused": 290 },
+  "timing":   { "elapsed_human": "1m 12s", "avg_render_seconds": 6.2,
+                "eta_seconds": 19, "eta_human": "19s", "eta_finish_epoch": 1781995960 },
+  "current":  { "chapter": 9, "text": "the sentence being rendered right now" }
+}
+```
+
+The **ETA is accurate** because, thanks to the cache, the run knows up front how
+many sentences are cache misses (must be rendered) vs hits (reused, ~instant):
+it estimates `remaining_renders × recent average render time` instead of a naive
+sentence count. After a one-paragraph edit, `to_render` is `1` and the ETA is
+seconds even for a long book.
 
 
 ###  Example of Custom Model Zip Upload

--- a/lib/core.py
+++ b/lib/core.py
@@ -2598,6 +2598,152 @@ def link_or_copy(src:str, dst:str)->bool:
         print(f'link_or_copy() error: {e}')
         return False
 
+# ---------------------------------------------------------------------
+# Machine-readable progress + ETA
+# ---------------------------------------------------------------------
+# The console only shows a tqdm bar (carriage-return updates, no ETA). This
+# writes a JSON snapshot to tmp/progress/<session>.json (and tmp/progress/
+# latest.json) on every update so a tool/agent can read live progress and an
+# accurate ETA at any time. ETA is accurate because, thanks to the content
+# cache, we know up front exactly how many sentences must actually be rendered
+# (cache misses) vs reused (hits) — so the estimate is remaining_renders *
+# average_render_time, not a naive count that ignores instant cache hits.
+progress_dir = os.path.join(tmp_dir, 'progress')
+
+def _fmt_duration(seconds:float|None)->str|None:
+    if seconds is None:
+        return None
+    seconds = int(max(0, seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f'{h}h {m}m {s}s'
+    if m:
+        return f'{m}m {s}s'
+    return f'{s}s'
+
+class ProgressTracker:
+    def __init__(self, session:dict, blocks:list, total_sentences:int, use_audio_cache:bool):
+        self.session = session
+        self.session_id = session.get('id')
+        self.total = total_sentences
+        self.use_cache = use_audio_cache
+        self.done = 0
+        self.rendered = 0
+        self.reused = 0
+        self.recent = []          # rolling window of render durations (seconds)
+        self.render_samples = 0
+        self.current = {}
+        self.status = 'running'
+        self.start_time = time.time()
+        self._last_write = 0.0
+        # pre-scan: how many sentences truly need TTS (cache misses) -> accurate ETA
+        self.to_render = self._scan_to_render(blocks)
+        os.makedirs(progress_dir, exist_ok=True)
+        self.path = os.path.join(progress_dir, f'{self.session_id}.json')
+        self.latest_path = os.path.join(progress_dir, 'latest.json')
+        print(f'PROGRESS_JSON: {self.path}')
+        self._write(force=True)
+
+    def _scan_to_render(self, blocks:list)->int:
+        if not self.use_cache:
+            return self.total
+        n = 0
+        for b in blocks:
+            if not (b.get('keep') and (b.get('text') or '').strip()):
+                continue
+            bv = b.get('voice') or self.session.get('voice')
+            for s in (b.get('sentences') or []):
+                if any(c.isalnum() for c in s.strip()):
+                    key = sentence_cache_key(self.session, s.strip(), bv)
+                    if not os.path.exists(os.path.join(tts_cache_dir, f'{key}.{default_audio_proc_format}')):
+                        n += 1
+        return n
+
+    def _avg_render(self)->float|None:
+        if self.render_samples == 0:
+            return None
+        window = self.recent[-30:]   # recent window tracks current hardware/speed
+        return sum(window) / len(window)
+
+    def _eta_seconds(self)->float|None:
+        avg = self._avg_render()
+        if avg is None:
+            return None
+        remaining_renders = max(0, self.to_render - self.rendered)
+        remaining_reused = max(0, (self.total - self.done) - remaining_renders)
+        return remaining_renders * avg + remaining_reused * 0.01   # reuse is ~instant
+
+    def tick(self, rendered:bool, render_seconds:float|None, text:str, chapter:int, done:int)->None:
+        self.done = done
+        if rendered:
+            self.rendered += 1
+            if render_seconds is not None:
+                self.render_samples += 1
+                self.recent.append(render_seconds)
+        else:
+            self.reused += 1
+        self.current = {'chapter': chapter, 'sentence_index': done, 'text': (text or '')[:200]}
+        self._write()
+
+    def tick_bulk(self, count:int, done:int)->None:
+        self.done = done
+        self.reused += count
+        self._write()
+
+    def finish(self, status:str)->None:
+        self.status = status
+        self._write(force=True)
+
+    def _write(self, force:bool=False)->None:
+        now = time.monotonic()
+        if not force and (now - self._last_write) < 1.0:
+            return
+        self._last_write = now
+        elapsed = time.time() - self.start_time
+        eta = self._eta_seconds()
+        avg = self._avg_render()
+        data = {
+            'session_id': self.session_id,
+            'ebook': Path(self.session.get('ebook') or '').name,
+            'language': self.session.get('language'),
+            'tts_engine': self.session.get('tts_engine'),
+            'voice': self.session.get('voice'),
+            'status': self.status,
+            'cache_enabled': self.use_cache,
+            'totals': {
+                'sentences': self.total,
+                'to_render': self.to_render,
+                'cached_at_start': max(0, self.total - self.to_render),
+            },
+            'progress': {
+                'done': self.done,
+                'rendered': self.rendered,
+                'reused': self.reused,
+                'percent': round(100.0 * self.done / self.total, 1) if self.total else 0.0,
+                'render_remaining': max(0, self.to_render - self.rendered),
+            },
+            'timing': {
+                'started_at': round(self.start_time, 3),
+                'updated_at': round(time.time(), 3),
+                'elapsed_seconds': round(elapsed, 1),
+                'elapsed_human': _fmt_duration(elapsed),
+                'avg_render_seconds': round(avg, 2) if avg is not None else None,
+                'eta_seconds': round(eta, 1) if eta is not None else None,
+                'eta_human': _fmt_duration(eta) if eta is not None else None,
+                'eta_finish_epoch': round(time.time() + eta) if eta is not None else None,
+            },
+            'current': self.current,
+        }
+        try:
+            tmp = f'{self.path}.tmp'
+            with open(tmp, 'w', encoding='utf-8') as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, self.path)
+            shutil.copyfile(self.path, self.latest_path)
+        except Exception as e:
+            print(f'progress write error: {e}')
+
 def convert_chapters2audio(session_id:str)->bool:
 
     def _reset_chapter_file(block_id:str)->None:
@@ -2691,6 +2837,7 @@ def convert_chapters2audio(session_id:str)->bool:
         ch_num = 0
         last_save_time = time.monotonic()
         baseline_initialized = False
+        progress_tracker = ProgressTracker(session, blocks, total_sentences, use_audio_cache)
         msg = (f'---------<br/>'
                f"{session['filename_noext']}<br/>"
                f"A total of {total_chapters} {'block' if total_chapters <= 1 else 'blocks'} "
@@ -2729,6 +2876,7 @@ def convert_chapters2audio(session_id:str)->bool:
                             cnt = len(valid_idx)
                             global_sent += cnt
                             t.update(cnt)
+                            progress_tracker.tick_bulk(cnt, global_sent)
                             continue
                         show_alert(session_id, {'type': 'warning', 'msg': f'Block {x} has {len(missing_sentences)} missing audio files, reconverting…'})
                         _reset_chapter_file(block_id)
@@ -2750,9 +2898,12 @@ def convert_chapters2audio(session_id:str)->bool:
                 for j in range(block_len):
                     if session['cancellation_requested']:
                         msg = 'Conversion Cancelled'
+                        progress_tracker.finish('cancelled')
                         return False
                     sentence = sentences[j].strip()
                     if j in valid_idx:
+                        rendered_now = False
+                        render_seconds = None
                         if j >= start_sentence or j in missing_sentences:
                             if j == start_sentence and start_sentence > 0:
                                 show_alert(session_id, {'type': 'info', 'msg': f'*** Resuming from sentence {global_sent} ***'})
@@ -2765,10 +2916,14 @@ def convert_chapters2audio(session_id:str)->bool:
                                     cache_hit = True
                                     print(f'Reused cached audio for sentence {global_sent}')
                             if not cache_hit:
+                                _render_t0 = time.monotonic()
                                 run, error = tts_manager.convert_sentence2audio(sentence_file, sentence, block_voice=block_voice)
                                 if not run:
                                     show_alert(session_id, {'type': 'warning', 'msg': error})
+                                    progress_tracker.finish('error')
                                     return False
+                                render_seconds = time.monotonic() - _render_t0
+                                rendered_now = True
                                 if cache_path is not None and os.path.exists(sentence_file):
                                     link_or_copy(sentence_file, cache_path)
                             converted = True
@@ -2790,6 +2945,7 @@ def convert_chapters2audio(session_id:str)->bool:
                         t.set_description(f'{total_progress * 100:.2f}%')
                         print(f' : {sentence}')
                         t.update(1)
+                        progress_tracker.tick(rendered_now, render_seconds, sentence, ch_num, global_sent)
                 sent_end = global_sent - 1
                 show_alert(session_id, {'type': 'info', 'msg': f'End of Chapter {ch_num} (block {x})'})
                 if converted or block_changed or missing_sentences or not os.path.exists(chapter_audio_file):
@@ -2806,8 +2962,13 @@ def convert_chapters2audio(session_id:str)->bool:
             save_db_stamp(session_id)
             session['blocks_saved'] = copy.deepcopy(blocks_current)
             save_json_blocks(session_id, 'blocks_saved')
+            progress_tracker.finish('done')
             return True
     except Exception as e:
+        try:
+            progress_tracker.finish('error')
+        except (NameError, AttributeError):
+            pass
         DependencyError(e)
         exception_alert(session_id, f'convert_chapters2audio() error: {e}')
         return False

--- a/lib/core.py
+++ b/lib/core.py
@@ -2513,6 +2513,91 @@ def block_hash(block: dict) -> str:
         )).encode('utf-8')
     ).hexdigest()
 
+# ---------------------------------------------------------------------
+# Content-addressed TTS cache
+# ---------------------------------------------------------------------
+# Per-sentence audio is expensive (TTS inference) but fully determined by the
+# sentence text + voice + engine + model + language + engine params. We store
+# each rendered sentence under tmp/tts_cache/<key>.<ext> keyed by that content,
+# independent of session id / block id / sentence position. So editing one
+# paragraph re-renders only its changed sentences; everything else (other
+# paragraphs, other chapters, reordered text, even a brand-new session with no
+# --session) is served from cache as a hardlink — no inference. Bump
+# tts_cache_version when a change to the audio pipeline should invalidate it.
+tts_cache_dir = os.path.join(tmp_dir, 'tts_cache')
+tts_cache_version = 1
+default_audio_cache_enabled = os.environ.get('EBOOK2AUDIO_TTS_CACHE', '1').strip().lower() not in ('0', 'false', 'no', 'off')
+
+def audio_cache_enabled(session:dict)->bool:
+    val = session.get('audio_cache')
+    if val is None:
+        return default_audio_cache_enabled
+    return bool(val)
+
+_voice_sig_cache = {}
+def voice_signature(voice:str)->str:
+    # Key the voice by CONTENT, not path: the engine copies the source voice to a
+    # per-session path (voices/__sessions/voice-<id>/...) that changes every run,
+    # but the processed bytes are deterministic from the source. Memoize per
+    # (path, size, mtime) so we hash each voice file at most once per run.
+    if not voice or not os.path.isfile(voice):
+        return voice or ''  # builtin speaker name / missing file: use the string
+    try:
+        st = os.stat(voice)
+        memo_key = (voice, st.st_size, int(st.st_mtime))
+        cached = _voice_sig_cache.get(memo_key)
+        if cached:
+            return cached
+        h = hashlib.sha1()
+        with open(voice, 'rb') as f:
+            for chunk in iter(lambda: f.read(1 << 20), b''):
+                h.update(chunk)
+        sig = h.hexdigest()
+        _voice_sig_cache[memo_key] = sig
+        return sig
+    except OSError:
+        return voice
+
+def sentence_cache_key(session:dict, sentence:str, block_voice:str|None)->str:
+    engine = session.get('tts_engine') or TTS_ENGINES['XTTS']
+    prefix = f'{engine.lower()}_'
+    # every engine param that can change the waveform (xtts_temperature, etc.)
+    params = {k: session[k] for k in sorted(session.keys())
+              if k.startswith(prefix) and session.get(k) is not None}
+    voice = block_voice or session.get('voice') or ''
+    voice_sig = voice_signature(voice)
+    lang = session.get('language') or ''
+    if session.get('translate_enabled') and session.get('translate'):
+        lang = session['translate']
+    payload = '|'.join((
+        f'v{tts_cache_version}',
+        engine,
+        session.get('fine_tuned') or 'internal',
+        lang,
+        session.get('language_iso1') or '',
+        voice_sig,
+        json.dumps(params, ensure_ascii=False, sort_keys=True),
+        (sentence or '').strip(),
+    ))
+    if os.environ.get('EBOOK2AUDIO_CACHE_DEBUG'):
+        print(f'[cachekey] engine={engine} ft={session.get("fine_tuned")} lang={lang} iso1={session.get("language_iso1")} '
+              f'voice_sig={voice_sig[:12]} params={json.dumps(params, sort_keys=True)} sent={ (sentence or "").strip()[:30]!r}')
+    return hashlib.sha1(payload.encode('utf-8')).hexdigest()
+
+def link_or_copy(src:str, dst:str)->bool:
+    # hardlink (instant, no extra disk; tmp/ is one filesystem) and fall back to copy
+    try:
+        if os.path.lexists(dst):
+            os.unlink(dst)
+        try:
+            os.link(src, dst)
+        except OSError:
+            shutil.copy2(src, dst)
+        return True
+    except Exception as e:
+        print(f'link_or_copy() error: {e}')
+        return False
+
 def convert_chapters2audio(session_id:str)->bool:
 
     def _reset_chapter_file(block_id:str)->None:
@@ -2545,6 +2630,9 @@ def convert_chapters2audio(session_id:str)->bool:
             return False
         print(f'*********** Session: {session_id} **************\n{session_info}')
         tts_manager = TTSManager(session)
+        use_audio_cache = audio_cache_enabled(session)
+        if use_audio_cache:
+            os.makedirs(tts_cache_dir, exist_ok=True)
         blocks_current = session['blocks_current']
         blocks = blocks_current['blocks']
         block_resume = blocks_current['block_resume']
@@ -2669,10 +2757,20 @@ def convert_chapters2audio(session_id:str)->bool:
                             if j == start_sentence and start_sentence > 0:
                                 show_alert(session_id, {'type': 'info', 'msg': f'*** Resuming from sentence {global_sent} ***'})
                             sentence_file = os.path.join(block_dir, f'{j}.{default_audio_proc_format}')
-                            run, error = tts_manager.convert_sentence2audio(sentence_file, sentence, block_voice=block_voice)
-                            if not run:
-                                show_alert(session_id, {'type': 'warning', 'msg': error})
-                                return False
+                            cache_path = None
+                            cache_hit = False
+                            if use_audio_cache:
+                                cache_path = os.path.join(tts_cache_dir, f'{sentence_cache_key(session, sentence, block_voice)}.{default_audio_proc_format}')
+                                if os.path.exists(cache_path) and link_or_copy(cache_path, sentence_file):
+                                    cache_hit = True
+                                    print(f'Reused cached audio for sentence {global_sent}')
+                            if not cache_hit:
+                                run, error = tts_manager.convert_sentence2audio(sentence_file, sentence, block_voice=block_voice)
+                                if not run:
+                                    show_alert(session_id, {'type': 'warning', 'msg': error})
+                                    return False
+                                if cache_path is not None and os.path.exists(sentence_file):
+                                    link_or_copy(sentence_file, cache_path)
                             converted = True
                             blocks_current['sentence_resume'] = j
                             now = time.monotonic()
@@ -2694,7 +2792,7 @@ def convert_chapters2audio(session_id:str)->bool:
                         t.update(1)
                 sent_end = global_sent - 1
                 show_alert(session_id, {'type': 'info', 'msg': f'End of Chapter {ch_num} (block {x})'})
-                if converted or block_changed or missing_sentences:
+                if converted or block_changed or missing_sentences or not os.path.exists(chapter_audio_file):
                     show_alert(session_id, {'type': 'info', 'msg': f'Combining chapter {ch_num} (block {x}) to audio, sentence {sent_start} to {sent_end}'})
                     session['blocks_current'] = blocks_current
                     save_db_stamp(session_id)


### PR DESCRIPTION
Two related changes that make iterating on a book far less painful: a content cache so small edits don't re-render the whole audiobook, and a machine-readable progress file with an accurate ETA. The second builds on the first, so they're in one PR.

---

## 1. Content-addressed TTS cache

### Problem

When you make a small edit to a book and re-convert, the whole audiobook re-renders from scratch, even though only a few sentences changed.

The existing per-sentence audio reuse only helps when **resuming an unchanged file**:

- A run without `--session` gets a fresh random session dir, so there is nothing to reuse.
- Editing the ebook changes its checksum, which deletes `blocks_saved` / `blocks_orig` / the progress DB and **regenerates random `uuid4` block ids**, orphaning the position-keyed sentence audio at `chapters/sentences/<block_id>/<j>.flac`.

So in practice any edit forces a full re-render.

### What this does

Each rendered sentence is stored at `tmp/tts_cache/<sha1>.<ext>` keyed by its content:

`engine + fine_tuned + language + voice(content) + engine params (e.g. xtts_*) + sentence text`

- **Cache hit:** hardlink the existing audio in, no inference.
- **Cache miss:** render, then populate the cache.

Because the key is the *content* (not session id, block id, or sentence position) and the cache lives **outside `process_dir`**, it survives session churn, edits, and reordering. Editing one paragraph re-renders only that paragraph; everything else, even a brand-new session with no `--session`, is served from cache.

Notes:
- **Voice is keyed by byte content, not path.** The engine copies the source voice to a per-session `voices/__sessions/voice-<id>/...` path that changes every run, so a path-based key would never hit. The processed bytes are deterministic from the source; the hash is memoized per file.
- **Engine-agnostic.** It wraps the common `convert_sentence2audio` entry point and folds every `<engine>_*` session param into the key.
- Enabled by default; disable with `EBOOK2AUDIO_TTS_CACHE=0`. Inspect keys with `EBOOK2AUDIO_CACHE_DEBUG=1`. Bump `tts_cache_version` to invalidate.

### Testing (XTTS, Spanish, CPU)

| Scenario | Result |
|---|---|
| Cold run | renders 2 paragraphs, writes 2 cache files |
| Warm run, fresh session (no `--session`) | **2 reuses, 0 TTS inferences**, cache unchanged |
| Edit one paragraph | **1 reuse + 1 inference**, cache grows by exactly 1 |

---

## 2. Machine-readable progress + ETA

### Problem

The console only shows a tqdm bar (carriage-return updates, no ETA), so a script or agent driving a conversion can't read progress or estimate completion.

### What this does

A `ProgressTracker` writes a JSON snapshot to `tmp/progress/<session>.json` (and `tmp/progress/latest.json`) on every update: `status`, `percent`, `done`/`total`, rendered vs reused counts, elapsed, average render time, and ETA (seconds, human-readable, and absolute finish epoch). The path is printed as `PROGRESS_JSON: <path>` at startup. Writes are throttled (~1/s) and atomic (temp file + `os.replace`).

The ETA is **accurate because of the cache**: a pre-scan counts, before any rendering, exactly how many sentences are cache misses (must render) vs hits (reused, ~instant). So `ETA = remaining_renders × recent_avg_render_time` rather than a naive sentence count. An edit touching one paragraph reports `to_render: 1` and a small ETA even in a large book.

### Example snapshot

```json
{
  "status": "running",
  "totals":   { "sentences": 6, "to_render": 1, "cached_at_start": 5 },
  "progress": { "percent": 50.0, "done": 3, "rendered": 3, "reused": 0, "render_remaining": 3 },
  "timing":   { "eta_human": "21s", "eta_seconds": 21, "avg_render_seconds": 7.04, "eta_finish_epoch": 1781995960 }
}
```

### Testing

| Scenario | Result |
|---|---|
| Full render | ETA converged 21s, 13s, 0s, matched the 37s actual; ended `status: done` |
| Edit one paragraph | pre-scan reported `to_render: 1, cached_at_start: 5` before rendering; finished in 4s (`rendered 1, reused 5`) |

---

## Scope

One file (`lib/core.py`): cache helpers next to `block_hash`, a cache lookup/populate around the existing `convert_sentence2audio` call, a `ProgressTracker`, and the tracker calls in the conversion loop. No behavior change when the cache is disabled.
