### PR TITLE
Fix headless Docker runs on CPU images (#1829)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ audiobooks/cli/*
 audiobooks/gui/gradio/*
 audiobooks/gui/host/*
 models/*
-tools
+tools/*
+!tools/detect_gpus.py
 tmp/*
 run/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ RUN find /app -type f \( -name "*.sh" -o -name "*.command" \) -exec sed -i 's/\r
 # Build dependencies via project script
 RUN ./ebook2audiobook.command --script_mode build_docker --docker_device "$DOCKER_DEVICE_STR"
 
+# Mark this as the prebuilt runtime image so the entrypoint defaults to
+# full_docker mode even when custom `docker run` args override the default CMD.
+ENV E2A_DOCKER_RUNTIME=1
+
 # Cleanup build-only packages and Rust toolchain to shrink the image
 RUN set -eux; \
     rustup self uninstall -y 2>/dev/null || true; \

--- a/ebook2audiobook.command
+++ b/ebook2audiobook.command
@@ -116,6 +116,12 @@ if [[ -n "${arguments[script_mode]+exists}" ]]; then
         echo "Error: Invalid script mode argument: ${arguments[script_mode]}"
         exit 1
     fi
+elif [[ "${E2A_DOCKER_RUNTIME:-0}" == "1" ]]; then
+    # Inside the prebuilt runtime image the build-only deps (cmake, rust, wget…)
+    # have been purged, so default to full_docker. This makes custom `docker run`
+    # args work without the user having to re-specify --script_mode full_docker
+    # (passing args to `docker run` overrides the image's default CMD).
+    SCRIPT_MODE="$FULL_DOCKER"
 fi
 
 if [[ -n "${arguments[docker_device]+exists}" ]]; then
@@ -179,18 +185,19 @@ if [[ -n "${arguments[headless]+exists}" && ! -n "${arguments[script_mode]+exist
 	else
 		APP_GROUP=$(stat -c '%G' "$SCRIPT_DIR")
 	fi
+	CURRENT_USER="${USER:-$(id -un)}"
 	user_in_group() {
-		id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx "$1"
+		id -nG "$CURRENT_USER" 2>/dev/null | tr ' ' '\n' | grep -qx "$1"
 	}
 	if ! user_in_group "$APP_GROUP"; then
-		echo "Adding $USER to group $APP_GROUP (requires sudo)..."
+		echo "Adding $CURRENT_USER to group $APP_GROUP (requires sudo)..."
 		if [[ "$OSTYPE" == "darwin"* ]]; then
-			sudo dseditgroup -o edit -a "$USER" -t user "$APP_GROUP"
+			sudo dseditgroup -o edit -a "$CURRENT_USER" -t user "$APP_GROUP"
 			echo "Group added. Please restart your terminal and re-run:"
 			echo "  $0 $*"
 			exit 0
 		else
-			sudo usermod -aG "$APP_GROUP" "$USER"
+			sudo usermod -aG "$APP_GROUP" "$CURRENT_USER"
 			exec sg "$APP_GROUP" -c "\"$0\" $*"
 		fi
 	fi
@@ -807,6 +814,13 @@ function install_python_packages {
 	python3 -m pip install --upgrade llvmlite numba --only-binary=:all:
 	total=$(grep -vE '^\s*($|#)' "$SCRIPT_DIR/requirements.txt" | wc -l | tr -d ' ')
 	i=0
+	# Determine the target device tag. On CPU targets the GPU onnxruntime wheel
+	# (onnxruntime-gpu) must not be installed: it pulls in the CUDA runtime
+	# (libcudart.so) which isn't present, so swap it for the CPU build.
+	local TARGET_TAG="${DEVICE_TAG:-}"
+	if [[ -z "$TARGET_TAG" && -f "$SCRIPT_DIR/.device_info.json" ]]; then
+		TARGET_TAG=$(python3 -c "import json;print(json.load(open('$SCRIPT_DIR/.device_info.json')).get('tag',''))" 2>/dev/null || true)
+	fi
 	progress_bar() {
 		local cur=$1 max=$2 width=30
 		local filled=$(( cur * width / max ))
@@ -814,6 +828,9 @@ function install_python_packages {
 	}
 	while IFS= read -r pkg || [[ -n "$pkg" ]]; do
 		[[ -z "$pkg" || "$pkg" == \#* ]] && continue
+		if [[ "$TARGET_TAG" == "cpu" && "$pkg" == onnxruntime-gpu* ]]; then
+			pkg="${pkg/onnxruntime-gpu/onnxruntime}"
+		fi
 		((i++))
 		progress_bar "$i" "$total"
 		echo " Installing $pkg"

--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -1024,6 +1024,33 @@ class DeviceInstaller():
         if op == '<': return left < right
         return False
 
+    def target_device_is_cpu(self)->bool:
+        # Determine whether the build targets a CPU-only device. Reads the device
+        # info written during the docker build (.device_info.json), falling back to
+        # the DOCKER_DEVICE_STR / DEVICE_TAG environment variables. Returns False
+        # when the target is unknown so GPU behaviour is preserved by default.
+        name = tag = ''
+        try:
+            if os.path.isfile(device_info_json):
+                with open(device_info_json, 'r', encoding='utf-8') as f:
+                    info = json.load(f)
+                name = str(info.get('name', '')).lower()
+                tag = str(info.get('tag', '')).lower()
+        except (OSError, json.JSONDecodeError):
+            pass
+        if not name:
+            env_str = os.environ.get('DOCKER_DEVICE_STR', '')
+            if env_str:
+                try:
+                    info = json.loads(env_str)
+                    name = str(info.get('name', '')).lower()
+                    tag = str(info.get('tag', '')).lower()
+                except json.JSONDecodeError:
+                    pass
+        if not tag:
+            tag = os.environ.get('DEVICE_TAG', '').lower()
+        return devices['CPU']['proc'] in (name, tag)
+
     def install_python_packages(self)->int:
         if not os.path.exists(requirements_file):
             error = f'Warning: File {requirements_file} not found. Skipping package check.'
@@ -1032,6 +1059,10 @@ class DeviceInstaller():
         overrides = {}
         if self.system == systems['MACOS'] or self.check_onnxruntime_directml():
             overrides['onnxruntime-gpu'] = None
+        elif self.target_device_is_cpu():
+            # CPU-only target: onnxruntime-gpu pulls in the CUDA runtime
+            # (libcudart.so) which isn't present, so install the CPU build instead.
+            overrides['onnxruntime-gpu'] = 'onnxruntime>=1.11.0'
         try:
             with open(requirements_file, 'r') as f:
                 contents = f.read().replace('\r', '\n')


### PR DESCRIPTION
## Fixes #1829 — headless Docker runs broken on the CPU image

Passing custom arguments to `docker run` overrides the image's default `CMD`
(`--script_mode full_docker`), which exposed four bugs that made headless CPU
runs fail. Each blocked the next, so the repro walks through all of them.

### Repro (before)
```
docker run -v ./ebooks:/app/ebooks -v ./audiobooks:/app/audiobooks \
  -v ./models:/app/models -v ./voices:/app/voices -v ./tmp:/app/tmp \
  --rm -it -p 7860:7860 athomasson2/ebook2audiobook:cpu \
  --headless --ebook /app/ebooks/book.epub --language eng
```
→ `ebook2audiobook.command: line 183: USER: unbound variable`
then, once each is fixed, in sequence:
`sudo: command not found` → missing `tools/detect_gpus.py` →
`ImportError: libcudart.so.13: cannot open shared object file`.

### Root causes & fixes
1. **`USER` unbound** under `set -u` (USER is unset in the container) — fall
   back to `id -un`.
2. **native-mode fallthrough**: dropping the default CMD left
   `SCRIPT_MODE=native`, so the script tried to reinstall the build-only deps
   the image deliberately purges (and called `sudo`, absent in the image). Mark
   the runtime image with `E2A_DOCKER_RUNTIME=1` and default to `full_docker`
   when it's set and no `--script_mode` was given.
3. **`tools/detect_gpus.py` missing**: `.dockerignore` excluded all of `tools/`,
   but `device_installer` runs that script. Narrow the ignore to keep it.
4. **`onnxruntime-gpu` on the CPU image** (pulls in the CUDA runtime): swap
   `onnxruntime-gpu` → `onnxruntime` for `cpu` targets in the bash build-path
   installer, plus the same guard in the Python device installer.

### Notes for reviewers
- **GPU builds unaffected**: the onnxruntime swap is gated on `tag == cpu`, and
  the `full_docker` default only triggers inside the prebuilt image (via the
  `E2A_DOCKER_RUNTIME` env baked in after the build step).
- There are **two** `install_python_packages` — a bash one (Docker build path)
  and a Python one (native/runtime path). Both are patched so the fix holds
  regardless of entry point.

### After
The same command runs to completion and produces the audiobook.
