### PR TITLE
fix(deps): replace legacy onnx-simplifier with onnxsim in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ llvmlite
 numba
 librosa>=0.9.2
 pytorch-lightning>=1.7.0
-onnx-simplifier>=0.4.10
+onnxsim>=0.4.10
 onnxscript>=0.7.0
 
 # E2A


### PR DESCRIPTION
The upstream project renamed its official PyPI package from onnx-simplifier to onnxsim. This has caused a multiple versions install loop.