### PR TITLE
Improve CUDA/ROCm detection and EPUB conversion reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ models/*
 !audiobooks/gui/gradio/.gitkeep
 !audiobooks/gui/host/.gitkeep
 .installed
+
+# Runtime-generated device metadata and downloaded voice models
+.device_info.json
+voices/*
+!voices/.gitkeep

--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -1215,6 +1215,13 @@ class DeviceInstaller():
                 try:
                     version(pkg_name)
                 except PackageNotFoundError:
+                    if pkg_name == 'unidic':
+                        spec = importlib.util.find_spec('unidic')
+                        if spec:
+                            for path in spec.submodule_search_locations or ():
+                                if os.path.isdir(path) and not os.listdir(path):
+                                    print(f'Removing stale UniDic package directory: {path}')
+                                    os.rmdir(path)
                     continue
                 msg = f'Removing obsolete package {pkg_name}…'
                 print(msg)

--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -425,7 +425,9 @@ class DeviceInstaller():
             # ============================================================
             # ROCm
             # ============================================================
-            elif has_rocm() and has_amd_gpu_pci():
+            # A common desktop setup has an NVIDIA dGPU and an AMD iGPU. Prefer
+            # a working CUDA device instead of selecting ROCm for the iGPU.
+            elif has_rocm() and has_amd_gpu_pci() and not has_cuda():
 
                 def _normalize_version(v:str)->tuple:
                     '''Parse version string into (major, minor, patch). Patch defaults to 0.'''
@@ -441,7 +443,7 @@ class DeviceInstaller():
                 os.environ['PYTORCH_HIP_ALLOC_CONF'] = 'expandable_segments:False'
                 version = ()
                 msg = ''
-                hip_device_count = 0
+                hip_runtime_has_no_devices = False
 
                 # 1) HIP runtime detection via ctypes (primary)
                 try:
@@ -490,8 +492,8 @@ class DeviceInstaller():
 
                     if libhip:
                         device_count = ctypes.c_int()
-                        if libhip.hipGetDeviceCount(ctypes.byref(device_count)) == 0:
-                            hip_device_count = device_count.value
+                        hip_status = libhip.hipGetDeviceCount(ctypes.byref(device_count))
+                        hip_runtime_has_no_devices = hip_status != 0 or device_count.value == 0
                         v_int = ctypes.c_int()
                         if libhip.hipRuntimeGetVersion(ctypes.byref(v_int)) == 0:
                             v = v_int.value
@@ -505,7 +507,7 @@ class DeviceInstaller():
                                 patch = 0
                             else:
                                 major, minor, patch = v, 0, 0
-                            if hip_device_count > 0:
+                            if not hip_runtime_has_no_devices:
                                 version = (major, minor, patch)
                             else:
                                 ver_disp = f'{major}.{minor}.{patch}' if patch else f'{major}.{minor}'
@@ -514,7 +516,7 @@ class DeviceInstaller():
                     pass
 
                 # 2) hipcc fallback
-                if not version:
+                if not version and not hip_runtime_has_no_devices:
                     if os.name == 'posix' and has_cmd('hipcc'):
                         out = try_cmd('hipcc --version')
                         if out:
@@ -538,7 +540,7 @@ class DeviceInstaller():
                                     version = _normalize_version(m.group(1))
 
                 # 3) torch.version.hip fallback
-                if not version:
+                if not version and not hip_runtime_has_no_devices:
                     try:
                         import torch
                         if getattr(torch.version, 'hip', None):
@@ -547,7 +549,7 @@ class DeviceInstaller():
                         pass
 
                 # 4) ROCm install dir fallback
-                if not version:
+                if not version and not hip_runtime_has_no_devices:
                     if os.name == 'posix':
                         for p in sorted(glob('/opt/rocm-*'), reverse=True):
                             base = os.path.basename(p).replace('rocm-', '')
@@ -586,7 +588,7 @@ class DeviceInstaller():
                                                 pass
                                 if version:
                                     break
-                if version:
+                if version and not hip_runtime_has_no_devices:
                     version_str = '.'.join(str(p) for p in version)
                     cmp, current, min_tuple, max_tuple = version_classify(version_str, rocm_version_range)
                     # min_ver / max_ver: strip trailing .0 for display (range tuples are major.minor)
@@ -623,11 +625,11 @@ class DeviceInstaller():
                             msg = f'ROCm {version_str} but tested max {max_ver} so using torch for {tag}' if tag else f'ROCm {version_str} detected but torch with this version not ready for your OS'
                         elif not tag:
                             msg = f'ROCm {version_str} detected but no compatible torch build for this OS.'
-                else:
+                elif not hip_runtime_has_no_devices:
                     msg = 'ROCm hardware detected but AMD ROCm base runtime not installed.'
 
                 # 5) Last-resort torch fallback
-                if not devices['ROCM']['found']:
+                if not devices['ROCM']['found'] and not hip_runtime_has_no_devices:
                     try:
                         import torch
                         if torch.cuda.is_available() and hasattr(torch.version, 'hip') and torch.version.hip:

--- a/lib/core.py
+++ b/lib/core.py
@@ -881,11 +881,11 @@ def normalize_epub_zip(session_id:str, file_input:str)->str|None:
         exception_alert(session_id, error)
     return None
 
-def convert2epub(session_id:str)->bool:
+def convert2epub(session_id:str)->tuple[bool, str|None]:
     session = context.get_session(session_id)
     if session and session.get('id', False):
         if session['cancellation_requested']:
-            return False
+            return False, 'Conversion cancelled'
         try:
             title = False
             author = False
@@ -893,21 +893,21 @@ def convert2epub(session_id:str)->bool:
             if not ebook_convert:
                 error = 'ebook-convert utility is not installed or not found.'
                 print(error)
-                return False
+                return False, error
             file_input = session['ebook']
             if os.path.getsize(file_input) == 0:
                 error = f'Input file is empty: {file_input}'
                 print(error)
-                return False
+                return False, error
             file_ext = os.path.splitext(file_input)[1].lower()
             if file_ext not in ebook_formats:
                 error = f'Unsupported file format: {file_ext}'
                 print(error)
-                return False
+                return False, error
             if file_ext == '.zip':
                 file_input = normalize_epub_zip(session_id, file_input)
                 if file_input is None:
-                    return False
+                    return False, 'Could not normalize ZIP ebook as EPUB.'
                 file_ext = '.epub'
             if file_ext == '.txt':
                 with open(file_input, 'r', encoding='utf-8') as f:
@@ -964,7 +964,7 @@ def convert2epub(session_id:str)->bool:
                     with open(file_input, 'w', encoding='utf-8') as html_file:
                         html_file.write(xhtml_text)
                 else:
-                    return False
+                    return False, 'No readable text was found in the PDF.'
             elif file_ext == '.pptx':
                 from html import escape as html_escape
                 from pptx import Presentation as PptxPresentation
@@ -1028,7 +1028,7 @@ def convert2epub(session_id:str)->bool:
                     with open(file_input, 'w', encoding='utf-8') as html_file:
                         html_file.write(xhtml_text)
                 else:
-                    return False
+                    return False, 'No readable text was found in the presentation.'
             elif file_ext == '.docx':
                 from docx import Document as DocxDocument
                 filename_noext = os.path.splitext(os.path.basename(session['ebook']))[0]
@@ -1079,7 +1079,7 @@ def convert2epub(session_id:str)->bool:
                         with open(file_input, 'w', encoding='utf-8') as html_file:
                             html_file.write(xhtml_text)
                     else:
-                        return False
+                        return False, 'No readable text or images were found in the DOCX file.'
             elif file_ext in ['.png', '.jpg', '.jpeg', '.tif', '.tiff', '.bmp']:
                 filename_noext = os.path.splitext(os.path.basename(session['ebook']))[0]
                 msg = f'File input is an image ({file_ext}). Running OCR…'
@@ -1113,7 +1113,7 @@ def convert2epub(session_id:str)->bool:
                         html_file.write(xhtml_text)
                     print(f'OCR completed for {page_count} image page(s).')
                 else:
-                    return False
+                    return False, 'OCR could not extract text from the image.'
             msg = f"Running command: {ebook_convert} {file_input} {session['epub_path']}"
             print(msg)
             cmd = [
@@ -1133,30 +1133,59 @@ def convert2epub(session_id:str)->bool:
                 cmd += ['--title', title]
             if author:
                 cmd += ['--authors', author]
+            calibre_dir = os.path.join(session['process_dir'], '.calibre')
+            os.makedirs(calibre_dir, exist_ok=True)
+            calibre_env = os.environ.copy()
+            calibre_env.update({
+                'CALIBRE_TEMP_DIR': calibre_dir,
+                'CALIBRE_CACHE_DIRECTORY': calibre_dir,
+                'CALIBRE_CONFIG_DIRECTORY': calibre_dir,
+            })
+            # Linux distro packages ship ebook-convert as an ``env python3`` script.
+            # When this app runs from Conda, that would load Calibre with the Conda
+            # interpreter instead of the system interpreter it was installed for.
+            try:
+                with open(ebook_convert, 'rb') as calibre_script:
+                    first_line = calibre_script.readline(256)
+                is_external_calibre = not Path(ebook_convert).resolve().is_relative_to(Path(sys.prefix).resolve())
+                if sys.platform.startswith('linux') and is_external_calibre and b'/usr/bin/env' in first_line and b'python' in first_line:
+                    calibre_env['PATH'] = os.defpath
+            except (IndexError, OSError):
+                pass
             result = subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                encoding='utf-8'
+                encoding='utf-8',
+                errors='replace',
+                env=calibre_env,
             )
-            print(result.stdout)
-            return True
-        except subprocess.CalledProcessError as e:
-            DependencyError(e)
-            error = f'convert2epub subprocess.CalledProcessError: {e.stderr}'
-            print(error)
-            return False
+            if result.stdout:
+                print(result.stdout)
+            if result.stderr:
+                print(result.stderr, file=sys.stderr)
+            if result.returncode != 0:
+                details = (result.stderr.strip() or result.stdout.strip() or 'no diagnostic output')[-4000:]
+                error = f'ebook-convert failed with exit code {result.returncode}: {details}'
+                print(error)
+                return False, error
+            if not os.path.isfile(session['epub_path']) or os.path.getsize(session['epub_path']) == 0:
+                error = f'ebook-convert completed without creating a valid EPUB: {session["epub_path"]}'
+                print(error)
+                return False, error
+            return True, None
         except FileNotFoundError as e:
             DependencyError(e)
             error = f'convert2epub FileNotFoundError: {e}'
             print(error)
-            return False
+            return False, error
         except Exception as e:
             DependencyError(e)
             error = f'convert2epub error: {e}'
             print(error)
-            return False
+            return False, error
+    return False, 'Session expired or does not exist.'
 
 def get_ebook_title(epubBook:EpubBook, all_docs:list[Any])->str|None:
     # 1. Try metadata (official EPUB title)
@@ -3715,7 +3744,7 @@ def convert_ebook(args:dict)->tuple:
                         ok_checksum, error = compare_checksums(session_id)
                         blocks_orig_old = {}
                         if not ok_checksum or not os.path.exists(session['epub_path']):
-                            result_epub = convert2epub(session_id)
+                            result_epub, conversion_error = convert2epub(session_id)
                             if result_epub:
                                 if os.path.exists(session['epub_path']):
                                     if os.path.exists(session['blocks_orig_json']):
@@ -3736,7 +3765,7 @@ def convert_ebook(args:dict)->tuple:
                                 else:
                                     error = f"convert2epub() {session['epub_path']} does not exists! check write permissions."
                             else:
-                                error = 'convert2epub() error: could not convert to epub file!'
+                                error = conversion_error or 'convert2epub() error: could not convert to epub file!'
                         if error is None:
                             missing_orig_json = True
                             is_changed = False


### PR DESCRIPTION
## Summary

- Prefer a working CUDA device when an NVIDIA GPU and an AMD iGPU are present, instead of selecting ROCm for the iGPU.
- Treat ROCm runtimes with no available HIP devices as unusable and improve fallback handling.
- Return actionable errors from `convert2epub` and isolate Calibre temp/cache/config files per session.
- Prevent external Calibre scripts from being launched with the Conda interpreter.
- Clean stale UniDic package directories and ignore runtime-generated device metadata and voice models.

## Testing

- Not run locally; changes are focused on device detection, installation cleanup, and EPUB conversion error handling.