### PR TITLE
Preserve sentence audio tails

### DIFF
--- a/lib/classes/tts_engines/common/audio.py
+++ b/lib/classes/tts_engines/common/audio.py
@@ -42,6 +42,21 @@ def detect_gender(voice_path:str)->str|None:
         print(error)
         return None
 
+NATURAL_TAIL_TARGET_SEC = 0.020
+NATURAL_TAIL_MAX_SEC = 0.050
+
+
+def _bounded_natural_tail_sec(buffer_sec: float) -> float:
+    """Return a short, bounded tail buffer for trimmed speech audio."""
+    return min(max(buffer_sec, NATURAL_TAIL_TARGET_SEC), NATURAL_TAIL_MAX_SEC)
+
+
+def _trimmed_end_index(last_non_silent_index: int, audio_length: int, samplerate: int, buffer_sec: float) -> int:
+    """Return an inclusive-safe end boundary for a trimmed waveform."""
+    tail_samples = int(_bounded_natural_tail_sec(buffer_sec) * samplerate)
+    return min(last_non_silent_index + 1 + tail_samples, audio_length)
+
+
 def trim_audio(audio_data: Union[list[float], 'Tensor'], samplerate: int, silence_threshold: float = 0.003, buffer_sec: float = 0.005)->'Tensor':
     import torch
     # Ensure audio_data is a PyTorch tensor
@@ -58,9 +73,10 @@ def trim_audio(audio_data: Union[list[float], 'Tensor'], samplerate: int, silenc
         non_silent_indices = torch.where(audio_data.abs() > silence_threshold)[0]
         if len(non_silent_indices) == 0:
             return torch.tensor([], dtype=audio_data.dtype)
-        # Calculate start and end trimming indices with buffer
+        # Keep the caller's leading buffer, but retain enough natural decay at
+        # the end for final phonemes without carrying sentence-length silence.
         start_index = max(non_silent_indices[0].item() - int(buffer_sec * samplerate), 0)
-        end_index = min(non_silent_indices[-1].item() + int(buffer_sec * samplerate), audio_data.size(0))
+        end_index = _trimmed_end_index(non_silent_indices[-1].item(), audio_data.size(0), samplerate, buffer_sec)
         return audio_data[start_index:end_index]
     error = 'audio_data must be a PyTorch tensor or a list of numerical values.'
     print(error)

--- a/tests/test_audio_tail_policy.py
+++ b/tests/test_audio_tail_policy.py
@@ -1,0 +1,45 @@
+"""Dependency-light regression tests for the shared audio tail policy."""
+
+import ast
+import pathlib
+import unittest
+
+
+def _load_policy_helpers():
+    source_path = pathlib.Path(__file__).parents[1] / "lib/classes/tts_engines/common/audio.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    wanted = {"NATURAL_TAIL_TARGET_SEC", "NATURAL_TAIL_MAX_SEC", "_bounded_natural_tail_sec", "_trimmed_end_index"}
+    nodes = []
+    for node in tree.body:
+        name = getattr(node, "name", None)
+        if name in wanted:
+            nodes.append(node)
+        elif isinstance(node, ast.Assign) and any(getattr(target, "id", None) in wanted for target in node.targets):
+            nodes.append(node)
+    namespace = {}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(source_path), "exec"), namespace)
+    return namespace
+
+
+class AudioTailPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = _load_policy_helpers()
+
+    def test_tail_buffer_is_at_least_natural_target_and_capped(self):
+        bounded = self.policy["_bounded_natural_tail_sec"]
+        self.assertEqual(bounded(0.002), 0.020)
+        self.assertEqual(bounded(0.035), 0.035)
+        self.assertEqual(bounded(0.100), 0.050)
+
+    def test_end_boundary_includes_last_audible_sample(self):
+        end_index = self.policy["_trimmed_end_index"]
+        self.assertEqual(end_index(7, 20, 1, 0.0), 8)
+
+    def test_end_boundary_is_clamped_to_audio_length(self):
+        end_index = self.policy["_trimmed_end_index"]
+        self.assertEqual(end_index(990, 1000, 24000, 0.006), 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Preserve natural sentence-ending audio tails while capping added silence
    at 50 ms. Add dependency-free regression tests for tail bounds and slice
    boundaries.
    
Created with GPT 5.6 Luna xhigh to fix the end of sentences being cut off.