### PR TITLE
Fix E2A-SML voice discovery in Docker

### DIFF
--- a/components/E2A-SML/Dockerfile
+++ b/components/E2A-SML/Dockerfile
@@ -23,5 +23,6 @@ RUN mkdir -p /ebook2audiobook
 # Expose Gradio default port
 EXPOSE 7861
 
-# Default: launch the web GUI accessible from outside the container
-CMD ["python", "cli.py", "--gui", "--host", "0.0.0.0"]
+# Download the shared voice library when the mounted repository does not have it,
+# then launch the web GUI accessible from outside the container.
+CMD ["python", "-m", "sml_extractor.docker_entrypoint"]

--- a/components/E2A-SML/README.md
+++ b/components/E2A-SML/README.md
@@ -197,6 +197,11 @@ Options:
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
 - [ebook2audiobook](https://github.com/DrewThomasson/ebook2audiobook) cloned locally (for the voice library)
 
+The standalone Docker image automatically downloads `voices.zip` from the
+[E2A-Voices dataset](https://huggingface.co/datasets/ebook2audiobook/E2A-Voices)
+when the mounted `voices/` directory has no WAV files. Existing voices are
+reused. Set `E2A_VOICES_REPO_ID` to use a different Hugging Face dataset.
+
 ### Local installation
 - Python 3.10+
 - [BookNLP-plus](https://github.com/DrewThomasson/booknlp) (installed via requirements.txt)

--- a/components/E2A-SML/requirements.txt
+++ b/components/E2A-SML/requirements.txt
@@ -8,6 +8,7 @@ tqdm>=4.65.0
 gradio>=4.0.0
 
 # Core dependencies
+huggingface_hub>=0.25.0
 torch>=2.0.0
 transformers>=4.30.0
 numpy>=1.24.0

--- a/components/E2A-SML/sml_extractor/docker_entrypoint.py
+++ b/components/E2A-SML/sml_extractor/docker_entrypoint.py
@@ -1,0 +1,26 @@
+"""Bootstrap dependencies required by the standalone E2A-SML container."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from .voice_library import DEFAULT_REPO_ID, configured_e2a_path, ensure_voice_library
+
+
+def main() -> None:
+    repo_id = os.environ.get("E2A_VOICES_REPO_ID", DEFAULT_REPO_ID)
+    try:
+        ensure_voice_library(configured_e2a_path(), repo_id=repo_id)
+    except Exception as exc:
+        print(f"Unable to prepare the ebook2audiobook voice library: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    os.execvp(
+        sys.executable,
+        [sys.executable, "cli.py", "--gui", "--host", "0.0.0.0"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/components/E2A-SML/sml_extractor/voice_library.py
+++ b/components/E2A-SML/sml_extractor/voice_library.py
@@ -1,0 +1,71 @@
+"""Download and safely install the shared ebook2audiobook voice library."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+DEFAULT_REPO_ID = "ebook2audiobook/E2A-Voices"
+DEFAULT_FILENAME = "voices.zip"
+
+
+def has_voices(voices_dir: Path) -> bool:
+    """Return whether a voice directory contains at least one WAV file."""
+    return voices_dir.is_dir() and any(voices_dir.rglob("*.wav"))
+
+
+def _safe_extract(archive: Path, destination: Path) -> None:
+    """Extract a ZIP archive while rejecting paths outside the destination."""
+    destination = destination.resolve()
+    with zipfile.ZipFile(archive) as bundle:
+        for member in bundle.infolist():
+            member_path = (destination / member.filename).resolve()
+            if member_path != destination and destination not in member_path.parents:
+                raise ValueError(f"Unsafe path in voice archive: {member.filename}")
+        bundle.extractall(destination)
+
+
+def ensure_voice_library(
+    e2a_path: str | Path,
+    repo_id: str = DEFAULT_REPO_ID,
+    filename: str = DEFAULT_FILENAME,
+) -> bool:
+    """Install the Hub voice archive if ``e2a_path/voices`` is empty.
+
+    Returns ``True`` when a download was performed and ``False`` when an
+    existing voice library was reused.
+    """
+    e2a_path = Path(e2a_path).expanduser().resolve()
+    voices_dir = e2a_path / "voices"
+    if has_voices(voices_dir):
+        return False
+
+    from huggingface_hub import hf_hub_download
+
+    e2a_path.mkdir(parents=True, exist_ok=True)
+    print(f"No voices found in {voices_dir}; downloading {repo_id}/{filename}...")
+    archive = Path(
+        hf_hub_download(repo_id=repo_id, filename=filename, repo_type="dataset")
+    )
+
+    with tempfile.TemporaryDirectory(prefix="e2a-voices-") as temp_dir:
+        extracted_root = Path(temp_dir)
+        _safe_extract(archive, extracted_root)
+        extracted_voices = extracted_root / "voices"
+        if not has_voices(extracted_voices):
+            raise RuntimeError("Downloaded voice archive contains no WAV files under voices/")
+        shutil.copytree(extracted_voices, voices_dir, dirs_exist_ok=True)
+
+    if not has_voices(voices_dir):
+        raise RuntimeError(f"Voice library installation failed: {voices_dir} is empty")
+    print(f"Voice library installed in {voices_dir}")
+    return True
+
+
+def configured_e2a_path() -> Path:
+    """Return the repository mount used by the standalone Docker image."""
+    return Path(os.environ.get("E2A_PATH", "/ebook2audiobook"))

--- a/components/E2A-SML/tests/test_voice_library.py
+++ b/components/E2A-SML/tests/test_voice_library.py
@@ -1,0 +1,52 @@
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sml_extractor.voice_library import _safe_extract, ensure_voice_library
+
+
+class VoiceLibraryTests(unittest.TestCase):
+    def test_existing_library_skips_download(self):
+        with tempfile.TemporaryDirectory() as root:
+            voice = Path(root, "voices", "eng", "adult", "female", "voice.wav")
+            voice.parent.mkdir(parents=True)
+            voice.write_bytes(b"wav")
+
+            self.assertFalse(ensure_voice_library(root))
+
+    def test_downloads_and_installs_voice_archive(self):
+        with tempfile.TemporaryDirectory() as root, tempfile.TemporaryDirectory() as source:
+            archive = Path(source, "voices.zip")
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("voices/eng/adult/female/voice.wav", b"wav")
+
+            download = Mock(return_value=str(archive))
+            fake_hub = SimpleNamespace(hf_hub_download=download)
+            with patch.dict("sys.modules", {"huggingface_hub": fake_hub}):
+                self.assertTrue(ensure_voice_library(root))
+
+            self.assertTrue(Path(root, "voices/eng/adult/female/voice.wav").is_file())
+            download.assert_called_once_with(
+                repo_id="ebook2audiobook/E2A-Voices",
+                filename="voices.zip",
+                repo_type="dataset",
+            )
+
+    def test_rejects_archive_path_traversal(self):
+        with tempfile.TemporaryDirectory() as root:
+            archive = Path(root, "voices.zip")
+            destination = Path(root, "extract")
+            destination.mkdir()
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("../escaped.wav", b"wav")
+
+            with self.assertRaisesRegex(ValueError, "Unsafe path"):
+                _safe_extract(archive, destination)
+            self.assertFalse(Path(root, "escaped.wav").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2050

## Summary
- bootstrap the shared E2A voice library when the standalone SML container starts with an empty `voices/` mount
- download `voices.zip` from the `ebook2audiobook/E2A-Voices` dataset using `huggingface_hub`
- reuse existing WAV files and support `E2A_PATH` / `E2A_VOICES_REPO_ID` overrides
- validate archive paths before extraction and report actionable startup failures
- document the Docker behavior and add focused unit coverage

## Testing
- `PYTHONPATH=components/E2A-SML python3 -m unittest discover -s components/E2A-SML/tests -v`
- `python3 -m compileall -q components/E2A-SML/sml_extractor components/E2A-SML/tests`
- `git diff --check`