### PR TITLE
fix: preserve natural sentence boundaries

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -18,6 +18,7 @@ from .conf_lang import (
     language_math_phonemes, language_clock, os, punctuation_list, 
     punctuation_list_set, punctuation_split_hard, punctuation_split_hard_set,
     punctuation_split_soft, punctuation_split_soft_set, punctuation_switch,
+    default_clause_split_words, language_clause_split_words,
     specialchars_mapping, chars_remove, year_to_decades_languages,
 )
 
@@ -48,6 +49,7 @@ __all__ = [
     "language_math_phonemes", "language_clock", "os", "punctuation_list", 
     "punctuation_list_set", "punctuation_split_hard", "punctuation_split_hard_set",
     "punctuation_split_soft", "punctuation_split_soft_set", "punctuation_switch",
+    "default_clause_split_words", "language_clause_split_words",
     "specialchars_mapping", "chars_remove", "year_to_decades_languages",
     
     # from conf_models

--- a/lib/classes/tts_engines/xtts.py
+++ b/lib/classes/tts_engines/xtts.py
@@ -113,6 +113,25 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
             error = f'load_engine() error: {e}'
             raise RuntimeError(error) from e
 
+    def _split_xtts_text(self, text:str, language:str|None=None)->list[str]:
+        try:
+            lang = (language or self.language_iso1 or self.language or 'en').split('-')[0]
+            if not hasattr(self.engine, 'tokenizer'):
+                return [text]
+            limit = getattr(self.engine.tokenizer, 'char_limits', {}).get(lang, 250)
+            if not limit or len(text) <= limit:
+                return [text]
+            try:
+                import TTS.tts.layers.xtts.tokenizer as xtts_tokenizer
+                chunks = xtts_tokenizer.split_sentence(text, lang, limit)
+                if chunks and any(chunk.strip() for chunk in chunks):
+                    return [c.strip() for c in chunks if c and c.strip()]
+            except Exception:
+                pass
+            return [text[i:i + limit] for i in range(0, len(text), limit)]
+        except Exception:
+            return [text]
+
     def convert(self, sentence_file:str, sentence:str, **kwargs)->tuple:
         try:
             import torch
@@ -144,60 +163,64 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
                         if part.endswith("'"):
                             part = part[:-1]
                         part = part.replace('.', ' ;\n')
-                        if self.params['current_voice'] is not None and self.params['current_voice'] in self.params['latent_embedding'].keys():
-                            self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.params['latent_embedding'][self.params['current_voice']]
-                        else:
-                            msg = 'Computing speaker latents…'
-                            print(msg)
-                            if self.speaker in default_engine_settings[TTS_ENGINES['XTTS']]['voices'].keys():
-                                self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.xtts_speakers[default_engine_settings[TTS_ENGINES['XTTS']]['voices'][self.speaker]].values()
+                        for text_chunk in self._split_xtts_text(part, self.language_iso1 or self.language):
+                            text_chunk = text_chunk.strip()
+                            if not text_chunk:
+                                continue
+                            if self.params['current_voice'] is not None and self.params['current_voice'] in self.params['latent_embedding'].keys():
+                                self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.params['latent_embedding'][self.params['current_voice']]
                             else:
-                                self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.engine.get_conditioning_latents(audio_path=[self.params['current_voice']], load_sr=24000, sound_norm_refs=True)
-                            self.params['latent_embedding'][self.params['current_voice']] = self.params['gpt_cond_latent'], self.params['speaker_embedding']
-                        result = False
-                        try:
-                            with torch.inference_mode():
-                                with torch.autocast(self.device, dtype=self.amp_dtype, enabled=(self.amp_dtype != torch.float32)):
-                                    result = self.engine.inference(
-                                        text=part,
-                                        language=self.language_iso1,
-                                        gpt_cond_latent=self.params['gpt_cond_latent'],
-                                        speaker_embedding=self.params['speaker_embedding'],
-                                        **self.fine_tuned_params
-                                    )
-                            if result:
-                                audio_part = result.get('wav')
-                                if audio_part is not None and len(audio_part) > 0:
-                                    if torch.is_tensor(audio_part):
-                                        audio_part = audio_part.detach().cpu()
-                                    if not is_audio_data_valid(audio_part):
+                                msg = 'Computing speaker latents…'
+                                print(msg)
+                                if self.speaker in default_engine_settings[TTS_ENGINES['XTTS']]['voices'].keys():
+                                    self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.xtts_speakers[default_engine_settings[TTS_ENGINES['XTTS']]['voices'][self.speaker]].values()
+                                else:
+                                    self.params['gpt_cond_latent'], self.params['speaker_embedding'] = self.engine.get_conditioning_latents(audio_path=[self.params['current_voice']], load_sr=24000, sound_norm_refs=True)
+                                self.params['latent_embedding'][self.params['current_voice']] = self.params['gpt_cond_latent'], self.params['speaker_embedding']
+                            result = False
+                            try:
+                                with torch.inference_mode():
+                                    with torch.autocast(self.device, dtype=self.amp_dtype, enabled=(self.amp_dtype != torch.float32)):
+                                        result = self.engine.inference(
+                                            text=text_chunk,
+                                            language=self.language_iso1,
+                                            gpt_cond_latent=self.params['gpt_cond_latent'],
+                                            speaker_embedding=self.params['speaker_embedding'],
+                                            **self.fine_tuned_params
+                                        )
+                                if result:
+                                    audio_part = result.get('wav')
+                                    if audio_part is not None and len(audio_part) > 0:
+                                        if torch.is_tensor(audio_part):
+                                            audio_part = audio_part.detach().cpu()
+                                        if not is_audio_data_valid(audio_part):
+                                            error = 'audio_part not valid'
+                                            return False, error
+                                        part_tensor = self._tensor_type(audio_part).unsqueeze(0)
+                                        if part_tensor.numel() == 0:
+                                            error = 'part_tensor not valid'
+                                            return False, error
+                                        if text_chunk[-1].isalnum() or text_chunk[-1] == '—':
+                                            part_tensor = trim_audio(part_tensor.squeeze(), self.params['samplerate'], 0.001, trim_audio_buffer).unsqueeze(0)
+                                        self.audio_segments.append(part_tensor)
+                                        if not re.search(r'\w$', text_chunk, flags=re.UNICODE) and text_chunk[-1] != '—':
+                                            silence_time = int(np.random.uniform(0.3, 0.6) * 100) / 100
+                                            self.audio_segments.append(torch.zeros(1, int(self.params['samplerate'] * silence_time)))
+                                    else:
                                         error = 'audio_part not valid'
                                         return False, error
-                                    part_tensor = self._tensor_type(audio_part).unsqueeze(0)
-                                    if part_tensor.numel() == 0:
-                                        error = 'part_tensor not valid'
-                                        return False, error
-                                    if part[-1].isalnum() or part[-1] == '—':
-                                        part_tensor = trim_audio(part_tensor.squeeze(), self.params['samplerate'], 0.001, trim_audio_buffer).unsqueeze(0)
-                                    self.audio_segments.append(part_tensor)
-                                    if not re.search(r'\w$', part, flags=re.UNICODE) and part[-1] != '—':
-                                        silence_time = int(np.random.uniform(0.3, 0.6) * 100) / 100
-                                        self.audio_segments.append(torch.zeros(1, int(self.params['samplerate'] * silence_time)))
                                 else:
                                     error = 'audio_part not valid'
                                     return False, error
-                            else:
-                                error = 'audio_part not valid'
+                            except IndexError as e:
+                                self.cleanup_memory()
+                                error = f'convert() error at {e} segment: {text_chunk}'
                                 return False, error
-                        except IndexError as e:
-                            self.cleanup_memory()
-                            error = f'convert() error at {e} segment: {part}'
-                            return False, error
-                        except Exception as e:
-                            # free the failed part's tensors before returning False;
-                            # core.py then unloads the engine via unload_tts_manager().
-                            self.cleanup_memory()
-                            return False, self.log_exception(f'{self.__class__.__name__}.convert() part loop', e)
+                            except Exception as e:
+                                # free the failed part's tensors before returning False;
+                                # core.py then unloads the engine via unload_tts_manager().
+                                self.cleanup_memory()
+                                return False, self.log_exception(f'{self.__class__.__name__}.convert() part loop', e)
                 if self.audio_segments:
                     segment_tensor = torch.cat(self.audio_segments, dim=-1)
                     if not self.audio_save(sentence_file, segment_tensor, self.params['samplerate']):

--- a/lib/conf_lang.py
+++ b/lib/conf_lang.py
@@ -56,20 +56,20 @@ punctuation_switch = {
     '‽': '?',    # Interrobang (U+200D) -> Replace with "?"
     '⁉': '?!',   # Exclamation question mark (U+2049) -> "?!"
     '‼': '!!',   # Double exclamation (U+200C) -> "!!"
-    
+
     # Odd Unicode punctuation that can create strange effects
     '⁈': '?!',  # Question mark with an exclamation mark
     '⁇': '??',  # Double question marks
     '﹖': '?',   # Small form question mark
     '﹗': '!',   # Small form exclamation mark
-    
+
     # Misinterpreted pauses
     '۔': '.',  # Arabic full stop
     '॥': '.',   # Devanagari double danda (used in Hindi, Bengali) -> Period
     '。': '.',  # Chinese full stop -> Period
     '።': '.',  # Ethiopic full stop
     '།': '.',    # Tibetan shad
-    
+
     # Miscellaneous
     '፡': ':',  # Ethiopic colon
     '፤': ';',  # Ethiopic semicolon
@@ -79,7 +79,7 @@ punctuation_switch = {
     '#': '-', # hashtag by Em Dash
     '†': '-', # Dagger (footnote marker) U+2020
     '¶': '-',  # Pilcrow (paragraph mark) U+0086
-    
+
     # Global replacement
     '—': '.',
     '(': ',',
@@ -150,6 +150,24 @@ punctuation_split_soft = [
     '໌', 'ໍ'
 ]
 punctuation_split_soft_set = set(punctuation_split_soft)
+
+# Clause connectors used as a last-resort sentence boundary. Keep the legacy fallback
+# unchanged so languages without dedicated entries retain the current segmentation behavior.
+default_clause_split_words = [
+    'et', 'ou', 'mais', 'car', 'donc', 'puis', 'alors', 'ensuite', 'cependant', 'pourtant',
+    'ainsi', 'tandis', 'parce', 'puisque', 'quand', 'comme', 'lorsque', 'si', 'or',
+    'bien que', 'quoique', 'quoi que', 'sans que', 'de sorte que', 'avant que', 'après que',
+    'pendant que', 'depuis que', 'tandis que', 'alors que', 'par contre', 'en revanche',
+    'au lieu de', 'au contraire', 'dès lors', "d'abord", 'ensuite', 'en effet', 'de plus',
+    'de même', 'également', 'non seulement', 'mais aussi', 'ce qui', 'ce que',
+    "c'est pourquoi", 'pourtant', 'néanmoins', 'toutefois', 'malgré cela', 'malgré tout',
+    'au final', 'finalement', 'au début', 'au bout', 'au moment où', 'où', 'lorsque',
+    'chaque fois que', 'si bien que', 'tellement que', 'assez pour que', 'trop pour que'
+]
+
+# Add language-specific connector lists here as they are reviewed. An entry overrides
+# the legacy fallback for that language without changing languages not yet covered.
+language_clause_split_words = {}
 
 chars_remove = [
     '\\', '|', '©', '®', '™',
@@ -930,9 +948,9 @@ language_mapping = {
     "tel": {"name": "Telugu", "native_name": "తెలుగు", "max_chars": 142, "script": "telugu"},
     "tur": {"name": "Turkish", "native_name": "Türkçe", "max_chars": 226, "script": "latin"},
     "yor": {"name": "Yoruba", "native_name": "Èdè Yorùbá", "max_chars": 142, "script": "latin"},
-    
+
     "zzz": {"name": "------------------ More languages (A to Z) ------------------", "native_name": "------------------ More languages (A to Z) ------------------", "max_chars": 182, "script": "latin"},
-    
+
     "abi": {"name": "Abidji", "native_name": "Abidji", "max_chars": 142, "script": "latin"},
     "ace": {"name": "Aceh", "native_name": "Acèh", "max_chars": 142, "script": "latin"},
     "aca": {"name": "Achagua", "native_name": "Achagua", "max_chars": 142, "script": "latin"},

--- a/lib/conf_models.py
+++ b/lib/conf_models.py
@@ -88,7 +88,7 @@ default_engine_settings = {
         "speed": 1.0,
         #"gpt_cond_len": 512,
         #"gpt_batch_size": 1,
-        "enable_text_splitting": False,
+        "enable_text_splitting": True,
         "files": ['config.json', 'model.pth', 'vocab.json', 'ref.wav'],
         "voice": default_speaker,
         "voices": {

--- a/lib/core.py
+++ b/lib/core.py
@@ -1860,37 +1860,108 @@ def get_sentences(session_id:str, text:str)->list|None:
 
     def _force_split_segment(segment:str)->list[str]:
         results = []
-        rest = segment
+        rest = segment.strip()
         hard_set = tuple(punctuation_split_hard_set)
         soft_set = tuple(punctuation_split_soft_set)
+
+        if not rest:
+            return []
+
+        clause_words = language_clause_split_words.get(lang, default_clause_split_words)
+        clause_pattern = re.compile(
+            r'(?i)\b(?:' + '|'.join(map(re.escape, clause_words)) + r')\b'
+        )
+
+        # If there is no punctuation at all, prefer a natural clause boundary instead of
+        # slicing in the middle of the phrase. This keeps long unpunctuated clauses readable.
+        if not any(ch in hard_set or ch in soft_set for ch in rest):
+            clause_positions = [m.end() for m in clause_pattern.finditer(rest) if m.end() > 0.35 * len(rest)]
+            if clause_positions:
+                best_idx = max(clause_positions)
+                left = rest[:best_idx].strip()
+                right = rest[best_idx:].strip()
+                if left and right:
+                    results.extend(_force_split_segment(left))
+                    results.extend(_force_split_segment(right))
+                    return results
+            return [rest]
+
         while rest:
             if _clean_len(rest) <= max_chars:
+                sentence_end = -1
+                for i, char in enumerate(rest[:-1]):
+                    if char not in hard_set:
+                        continue
+                    j = i + 1
+                    while j < len(rest) and rest[j].isspace():
+                        j += 1
+                    if j < len(rest) and (rest[j].isupper() or rest[j].isdigit()):
+                        sentence_end = i + 1
+                        break
+                if sentence_end > 0:
+                    results.append(rest[:sentence_end].strip())
+                    rest = rest[sentence_end:].strip()
+                    continue
                 results.append(rest.strip())
                 break
-            cut = rest[:max_chars + 1]
+
+            target = min(len(rest), max_chars)
             best_idx = -1
-            # 1) regress to the last hard punctuation in the window
-            for i in range(len(cut) - 1, -1, -1):
-                if cut[i] in hard_set:
+
+            # 1) prefer a real sentence-ending punctuation before the target length
+            for i in range(min(target, len(rest) - 1), -1, -1):
+                if rest[i] in hard_set:
                     best_idx = i + 1
                     break
-            # 2) no hard punct -> regress to the last soft punctuation
+
+            # 2) if no hard end was found nearby, allow a hard sentence end a little beyond the
+            # target when it truly closes the sentence (next token starts a new sentence)
             if best_idx == -1:
-                for i in range(len(cut) - 1, -1, -1):
-                    if cut[i] in soft_set:
-                        best_idx = i + 1
-                        break
-            # 3) no punctuation at all -> fall back to last space
+                scan_end = min(len(rest) - 1, target + max_chars * 2)
+                for i in range(target, scan_end + 1):
+                    if rest[i] in hard_set:
+                        j = i + 1
+                        while j < len(rest) and rest[j].isspace():
+                            j += 1
+                        next_text = rest[j:j + 20]
+                        if next_text and (next_text[0].isupper() or next_text[0].isdigit()):
+                            best_idx = i + 1
+                            break
+
+            # 3) soft punctuation is the preferred natural split before clause connectors.
+            # In practice, users prefer a later comma/semicolon over an earlier conjunction
+            # when the sentence is long, because it preserves the narration rhythm. Never
+            # search beyond the next hard sentence boundary.
             if best_idx == -1:
-                idx = cut.rfind(' ')
+                next_hard_end = next(
+                    (i for i in range(target, len(rest)) if rest[i] in hard_set),
+                    len(rest)
+                )
+                for i in range(next_hard_end - 1, -1, -1):
+                    if rest[i] in soft_set:
+                        if i >= max_chars * 0.35 or i >= target:
+                            best_idx = i + 1
+                            break
+
+            # 4) if there is still no safe break, prefer a clause connector before the target
+            if best_idx == -1:
+                clause_positions = [m.end() for m in clause_pattern.finditer(rest[:target]) if m.end() > 0.35 * target]
+                if clause_positions:
+                    best_idx = max(clause_positions)
+
+            # 5) final fallback: whitespace near the max length
+            if best_idx == -1:
+                idx = rest.rfind(' ', 0, target)
                 if idx > 0:
-                    best_idx = idx
-            # 4) last resort -> hard cut at max_chars
-            if best_idx <= 0:
-                best_idx = max_chars
+                    best_idx = idx + 1
+
+            if best_idx <= 0 or best_idx >= len(rest):
+                best_idx = max(1, min(len(rest) - 1, target))
+
             # Safety: never cut inside an SML group
             while best_idx < len(rest) and ord(rest[best_idx]) >= sml_escape_tag:
                 best_idx += 1
+
             left = rest[:best_idx].strip()
             right = rest[best_idx:].strip()
             if not left or right == rest:
@@ -2016,48 +2087,21 @@ def get_sentences(session_id:str, text:str)->list|None:
             if combined:
                 if _strip_escaped_sml(combined).strip():
                     if _clean_len(combined) <= max_chars:
-                        final_list.append(combined)
+                        final_list.extend(_force_split_segment(combined))
                     else:
                         final_list.extend(_force_split_segment(combined))
                 elif final_list:
                     # Trailing pure-SML — attach to last sentence, no standalone
                     final_list[-1] = final_list[-1].rstrip() + ' ' + combined
 
-        final_list = [_strip_leading_noise(s) for s in final_list if s.strip()]
+        normalized_list = []
+        for item in final_list:
+            if _clean_len(item) <= max_chars:
+                normalized_list.extend(_force_split_segment(item))
+            else:
+                normalized_list.append(item)
+        final_list = [_strip_leading_noise(s) for s in normalized_list if s.strip()]
         final_list = [s for s in final_list if s]
-
-        # Merge orphan-short sentences. A sentence below max_chars/2 is "too short";
-        # absorb it into the previous (preferred) or next sentence when that fits.
-        merge_threshold = max_chars // 2
-        merge_ceiling   = max_chars + max_chars // 2   # max_chars + overhead of max_chars/2
-
-        merged_list = []
-        i = 0
-        n = len(final_list)
-        while i < n:
-            cur = final_list[i].strip()
-            if not cur:
-                i += 1
-                continue
-            cur_len = _clean_len(cur)
-            if cur_len <= merge_threshold:
-                # 1) try to attach to the previous sentence
-                if merged_list:
-                    prev = merged_list[-1]
-                    if _clean_len(prev) + 1 + cur_len <= merge_ceiling:
-                        merged_list[-1] = prev.rstrip() + ' ' + cur.lstrip()
-                        i += 1
-                        continue
-                # 2) otherwise try to glue it onto the next sentence
-                if i + 1 < n:
-                    nxt = final_list[i + 1].strip()
-                    if cur_len + 1 + _clean_len(nxt) <= merge_ceiling:
-                        merged_list.append(cur.rstrip() + ' ' + nxt.lstrip())
-                        i += 2
-                        continue
-            merged_list.append(cur)
-            i += 1
-        final_list = merged_list
 
         if lang in ['zho', 'jpn', 'kor', 'tha', 'lao', 'mya', 'khm']:
             result = []

--- a/tests/test_sentence_splitting.py
+++ b/tests/test_sentence_splitting.py
@@ -1,0 +1,158 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import lib.core as core
+from lib.core import SessionContext
+
+
+def test_get_sentences_prefers_sentence_boundaries_over_comma_and_semicolon():
+    ctx = SessionContext()
+    ctx.set_session('segment_test')
+    session = ctx.get_session('segment_test')
+    session['language'] = 'fra'
+    session['translate_enabled'] = False
+    session['translate'] = None
+    session['tts_engine'] = 'XTTS'
+    core.context = ctx
+
+    text = (
+        "Un soleil de fin de journée teintait de reflets roses la grisaille de son point culminant "
+        "et s'enfonçait dans le noir vers sa base; un feu de broussailles remontait la colline sur le côté gauche de la fissure. "
+        "Bosch régla son scanner sur la fréquence des services d'intervention du comté de Los Angeles "
+        "et entendit les capitaines des détachements de pompiers informer le poste de commandement que neuf maisons "
+        "avaient déjà été détruites dans une rue, celles de la rue voisine se trouvant maintenant sur le chemin des flammes."
+    )
+
+    segments = core.get_sentences('segment_test', text)
+    assert segments, 'Expected at least one segment'
+
+    joined = ' '.join(segment.strip() for segment in segments if segment.strip())
+    assert 'rue, celles de la rue voisine' in joined
+    assert 'base; un feu de broussailles' in joined
+
+    # A forced split may legitimately land on the last comma / semicolon before a natural
+    # continuation, since the user prefers that over splitting at an earlier conjunction.
+    # The character cap is still enforced elsewhere by the XTTS guard; the intent here is
+    # narrative rhythm, not a strict per-sentence max-length requirement.
+    assert any('une rue,' in segment for segment in segments)
+
+
+def test_get_sentences_does_not_force_split_inside_clause_without_punctuation():
+    ctx = SessionContext()
+    ctx.set_session('segment_test_no_punct')
+    session = ctx.get_session('segment_test_no_punct')
+    session['language'] = 'fra'
+    session['translate_enabled'] = False
+    session['translate'] = None
+    session['tts_engine'] = 'XTTS'
+    core.context = ctx
+
+    text = (
+        "Bosch régla son scanner sur la fréquence des services d'intervention du comté de Los Angeles "
+        "et entendit les capitaines des détachements de pompiers informer le poste de commandement "
+        "que neuf maisons avaient déjà été détruites dans une rue, celles de la rue voisine se trouvant "
+        "maintenant sur le chemin des flammes."
+    )
+
+    segments = core.get_sentences('segment_test_no_punct', text)
+    assert segments
+    assert any('détachements de pompiers informer' in segment for segment in segments)
+    assert not any('détachements' in segment and 'de pompiers' not in segment for segment in segments)
+
+
+def test_get_sentences_splits_long_unpunctuated_clause_on_clause_boundaries():
+    ctx = SessionContext()
+    ctx.set_session('segment_test_clause_fallback')
+    session = ctx.get_session('segment_test_clause_fallback')
+    session['language'] = 'fra'
+    session['translate_enabled'] = False
+    session['translate'] = None
+    session['tts_engine'] = 'XTTS'
+    core.context = ctx
+
+    text = (
+        "Bosch traversa le quartier et observa les voitures immobilisées et les portes ouvertes et les habitants qui couraient "
+        "vers les bus et les sirènes qui résonnaient au loin et les flammes qui montaient au-dessus des maisons et les camions "
+        "de pompiers qui s'arrêtèrent devant la rue et les équipes qui se déployèrent en file indienne pour bloquer l'accès "
+        "et protéger les familles encore présentes dans le voisinage."
+    )
+
+    segments = core.get_sentences('segment_test_clause_fallback', text)
+    assert segments
+    assert len(segments) > 1
+    assert max(len(segment) for segment in segments if segment.strip()) <= core.language_mapping['fra']['max_chars']
+    assert any('camions de pompiers' in segment for segment in segments)
+
+
+def test_get_sentences_keeps_final_phrase_before_real_sentence_end():
+    ctx = SessionContext()
+    ctx.set_session('segment_test_final_phrase')
+    session = ctx.get_session('segment_test_final_phrase')
+    session['language'] = 'fra'
+    session['translate_enabled'] = False
+    session['translate'] = None
+    session['tts_engine'] = 'XTTS'
+    core.context = ctx
+
+    text = (
+        "C'était seulement lorsque Bosch quittait la véranda pour rentrer dans la maison que l'animal s'avançait à pas feutrés afin "
+        "de s'emparer des offrandes. Harry l'avait baptisé Timido. Parfois, en pleine nuit, il entendait ses hurlements résonner au "
+        "fond du canyon."
+    )
+
+    segments = core.get_sentences('segment_test_final_phrase', text)
+    assert segments
+    assert any("s'emparer des offrandes." in segment for segment in segments)
+    assert not any("s'emparer" in segment and "des offrandes" not in segment for segment in segments)
+
+
+def test_get_sentences_prefers_last_comma_over_earlier_clause_connector():
+    ctx = SessionContext()
+    ctx.set_session('segment_test_comma_preference')
+    session = ctx.get_session('segment_test_comma_preference')
+    session['language'] = 'fra'
+    session['translate_enabled'] = False
+    session['translate'] = None
+    session['tts_engine'] = 'XTTS'
+    core.context = ctx
+
+    text = (
+        "Bosch régla son scanner sur la fréquence des services d'intervention du comté de Los Angeles et "
+        "entendit les capitaines des détachements de pompiers informer le poste de commandement que neuf maisons "
+        "avaient déjà été détruites dans une rue, celles de la rue voisine se trouvant maintenant sur le chemin des flammes."
+    )
+
+    segments = core.get_sentences('segment_test_comma_preference', text)
+    assert segments
+    assert any('une rue,' in segment for segment in segments)
+    assert 'celles de la rue voisine' in ' '.join(segments)
+    assert not any('Los Angeles et' in segment and 'entendit' not in segment for segment in segments)
+
+
+def test_get_sentences_does_not_merge_short_sentences_across_sentence_boundaries():
+    ctx = SessionContext()
+    ctx.set_session('segment_test_short_sentences')
+    session = ctx.get_session('segment_test_short_sentences')
+    session['language'] = 'fra'
+    session['translate_enabled'] = False
+    session['translate'] = None
+    session['tts_engine'] = 'XTTS'
+    core.context = ctx
+
+    text = (
+        "Il regarda l'escadrille des hélicoptères; semblables à des libellules à cette distance, "
+        "ils zigzaguaient entre les nuages de fumée avant de larguer des tonnes d'eau et de retardateur "
+        "de couleur rose sur les maisons et les arbres en feu. Cela lui rappela les offensives aériennes "
+        "au Vietnam. Le bruit. La danse hésitante des appareils surchargés. Des masses d'eau traversaient "
+        "des toits en feu, de la vapeur s'élevant aussitôt dans le ciel."
+    )
+
+    segments = core.get_sentences('segment_test_short_sentences', text)
+    assert segments
+    assert any(segment.strip() == 'Le bruit.' for segment in segments)
+    assert any(segment.strip() == 'La danse hésitante des appareils surchargés.' for segment in segments)
+    assert not any('en feu. Cela' in segment for segment in segments)
+    assert not any('Vietnam. Le bruit.' in segment for segment in segments)
+    assert not any('Le bruit. La danse' in segment for segment in segments)


### PR DESCRIPTION
# Fix Sentence Segmentation for More Natural Audiobook Narration

## Problem

During ebook-to-audiobook conversion, long passages could be split at unnatural positions:

- in the middle of a clause;
- immediately after conjunctions such as `and`, `but`, or `because`;
- at a comma located much later in the text;
- between several intentionally short expressive sentences;
- across a real sentence boundary.

This could produce overly long segments and unnatural narration.

XTTS also rejects input exceeding its maximum limit of 400 tokens.

## Real-World Example

For example, this French passage could previously be split like this:

```text
Bosch régla son scanner sur la fréquence des services d'intervention du comté de Los Angeles et
entendit les capitaines des détachements de pompiers informer le poste de commandement que neuf maisons
avaient déjà été détruites dans une rue,
celles de la rue voisine se trouvant maintenant sur le chemin des flammes.
```

The first split occurs immediately after the conjunction `et`, leaving the first segment grammatically unfinished.

The passage means:

> Bosch tuned his scanner to the frequency used by the Los Angeles County emergency services and heard the fire department captains inform the command post that nine houses had already been destroyed on one street, while the houses on the neighboring street were now in the path of the flames.

A more natural segmentation is:

```text
Bosch régla son scanner sur la fréquence des services d'intervention du comté de Los Angeles et entendit les capitaines des détachements de pompiers informer le poste de commandement que neuf maisons avaient déjà été détruites dans une rue,
celles de la rue voisine se trouvant maintenant sur le chemin des flammes.
```

This keeps the complete clause together and uses the later comma as the narration break.

Another real example contains several short, intentionally expressive sentences:

```text
Il regarda l'escadrille des hélicoptères; semblables à des libellules à cette distance, ils zigzaguaient entre les nuages de fumée avant de larguer des tonnes d'eau et de retardateur de couleur rose sur les maisons et les arbres en feu. Cela lui rappela les offensives aériennes au Vietnam. Le bruit. La danse hésitante des appareils surchargés. Des masses d'eau traversaient des toits en feu, de la vapeur s'élevant aussitôt dans le ciel.
```

The English translation is:

> He watched the helicopter formation; like dragonflies at that distance, they zigzagged between the clouds of smoke before dropping tons of water and pink retardant on the burning houses and trees. It reminded him of the air offensives in Vietnam. The noise. The hesitant dance of the overloaded aircraft. Masses of water passed through burning roofs, steam rising immediately into the sky.

The sentences `Le bruit.` and `La danse hésitante...` are deliberate narrative fragments and should remain separate.

## Changes

The sentence splitter now:

1. Prioritizes real sentence endings such as `.`, `!`, and `?`.
2. Prevents commas and clause connectors from crossing real sentence boundaries.
3. Prefers intermediate punctuation such as `;`, `:`, and `,` inside a long sentence.
4. Prefers a natural comma break over an earlier clause connector when appropriate.
5. Uses clause connectors only as a fallback when punctuation is unavailable.
6. Preserves short expressive sentences instead of merging them with neighboring text.
7. Keeps linguistic connector data outside the core algorithm.
8. Splits oversized XTTS inputs before inference to avoid the 400-token limit.

## Language Configuration

Clause connectors are now stored in `lib/conf_lang.py` instead of being embedded directly in `lib/core.py`.

This makes the logic easier to maintain and allows language-specific connector lists to be added later without modifying the segmentation algorithm.

The existing fallback list is preserved to avoid changing behavior for languages that do not yet have dedicated configuration.

## Tests

Regression tests cover:

- real sentence boundaries;
- long clauses;
- long text without punctuation;
- comma preference over an earlier conjunction;
- preservation of complete final phrases;
- short expressive sentences.

Validation result:

```text
6 passed
```

## Known Limitations

This remains a heuristic splitter and does not perform complete syntactic analysis.

Some cases may still require additional language-specific rules, including:

- very long sentences without punctuation;
- abbreviations containing periods;
- complex dialogue;
- incorrectly punctuated source text;
- languages without dedicated connector configuration;
- unusual grammatical structures.

The current fallback behavior is intentionally preserved for compatibility.
