### PR TITLE
Fix UnboundLocalError in detect_device by hoisting _normalize_version

### DIFF
--- a/lib/classes/device_installer.py
+++ b/lib/classes/device_installer.py
@@ -223,6 +223,16 @@ class DeviceInstaller():
                 return m.group(3)
             return None
 
+        def _normalize_version(v:str)->tuple:
+            '''Parse version string into (major, minor, patch). Patch defaults to 0.'''
+            m = re.search(r'(\d+)\.(\d+)(?:\.(\d+))?', v or '')
+            if not m:
+                return ()
+            major = int(m.group(1))
+            minor = int(m.group(2))
+            patch = int(m.group(3)) if m.group(3) else 0
+            return (major, minor, patch)
+
         def version_classify(version_str:Union[str, None], version_range:dict)->tuple:
             # Returns (cmp, current_tuple, min_tuple, max_tuple)
             # cmp: -1 = below min, 0 = in range, 1 = above max, None = parse fail / unranged
@@ -494,16 +504,6 @@ class DeviceInstaller():
             # ROCm
             # ============================================================
             elif has_rocm() and has_amd_gpu_pci():
-
-                def _normalize_version(v:str)->tuple:
-                    '''Parse version string into (major, minor, patch). Patch defaults to 0.'''
-                    m = re.search(r'(\d+)\.(\d+)(?:\.(\d+))?', v or '')
-                    if not m:
-                        return ()
-                    major = int(m.group(1))
-                    minor = int(m.group(2))
-                    patch = int(m.group(3)) if m.group(3) else 0
-                    return (major, minor, patch)
 
                 os.environ['PYTORCH_CUDA_ALLOC_CONF'] = 'expandable_segments:False'
                 os.environ['PYTORCH_HIP_ALLOC_CONF'] = 'expandable_segments:False'


### PR DESCRIPTION
## Problem

`check_device_info()` fails during installation on non-ROCm machines with:

```
UnboundLocalError: cannot access local variable '_normalize_version'
where it is not associated with a value
```

at `device_installer.py:845` in `detect_device()`.

## Root cause

`_normalize_version()` is defined **inside** the ROCm branch:

```python
elif has_rocm() and has_amd_gpu_pci():
    def _normalize_version(v: str) -> tuple:
        ...
```

but it is also called from the **CUDA** branch (the `tag_ver = _normalize_version(ver_str)` paths). On a machine that takes the CUDA path (CUDA toolkit + NVIDIA GPU, or WSL2) but not the ROCm path, the function is never bound, so the call raises `UnboundLocalError`.

## Fix

Move the single definition to the top of `detect_device()`, next to the other helper closures (`lib_version_parse`, `version_classify`, etc.), so it is in scope for every device branch. No behavioral change — pure scope fix.

## Verification

- `python -m py_compile lib/classes/device_installer.py` passes.
- Ran `detect_device()` end-to-end on a non-ROCm machine (Intel oneAPI / XPU path): returns `('xpu', 'xpu', '...')` without exception.
- AST check confirms `_normalize_version` is now a top-level definition of `detect_device` (no longer nested under any `if`/`elif`).

Fixes #2066