### PR TITLE
Add Vietnamese VietXTTS preset

### DIFF
--- a/lib/classes/tts_engines/common/preset_loader.py
+++ b/lib/classes/tts_engines/common/preset_loader.py
@@ -5,6 +5,14 @@ from typing import Dict, Any
 _lock = threading.Lock()
 _presets_cache:Dict[str, Dict[str, Any]] = {}
 
+def get_compatible_presets(models:Dict[str, Dict[str, Any]], language:str)->list[str]:
+    return [
+        name
+        for name, details in models.items()
+        if details.get('lang') in ('multi', language)
+        and language not in details.get('exclude_langs', ())
+    ]
+
 def load_engine_presets(engine:str)->Dict[str, Any]:
     with _lock:
         if engine in _presets_cache:

--- a/lib/classes/tts_engines/common/utils.py
+++ b/lib/classes/tts_engines/common/utils.py
@@ -789,6 +789,9 @@ class TTSUtils:
 
     def _set_voice(self, voice:str|None)->tuple:
         current_voice = (voice if voice is not None else self.models[self.session['fine_tuned']]['voice'])
+        preset_voice = self.models[self.session['fine_tuned']].get('voice')
+        if current_voice == preset_voice and current_voice is not None and os.path.exists(current_voice):
+            return current_voice, None
         if current_voice is None:
             if self.session['custom_model'] is not None:
                 voice_file = f"{Path(self.session['custom_model']).stem}.wav"

--- a/lib/classes/tts_engines/presets/xtts_presets.py
+++ b/lib/classes/tts_engines/presets/xtts_presets.py
@@ -11,6 +11,15 @@ models = {
         "files": default_engine_settings[TTS_ENGINES['XTTS']]['files'],
         "samplerate": default_engine_settings[TTS_ENGINES['XTTS']]['samplerate']
     },
+    "VietXTTS": {
+        "lang": "vie",
+        "repo": "drewThomasson/fineTunedTTSModels",
+        "sub": "Viet-xtts-v2/",
+        "voice": None,
+        "voice_sub": "Viet-xtts-v2/samples/vi_sample.wav",
+        "files": default_engine_settings[TTS_ENGINES['XTTS']]['files'],
+        "samplerate": default_engine_settings[TTS_ENGINES['XTTS']]['samplerate']
+    },
     "AiExplained": {
         "lang": "eng",
         "repo": "drewThomasson/fineTunedTTSModels",

--- a/lib/classes/tts_engines/presets/xtts_presets.py
+++ b/lib/classes/tts_engines/presets/xtts_presets.py
@@ -5,22 +5,22 @@ from lib.conf_models import TTS_ENGINES, default_engine_settings
 models = {
     "internal": {
         "lang": "multi",
-        "exclude_langs": ("vie",),
+        'exclude_langs': ('vie',),
         "repo": "coqui/XTTS-v2",
         "sub": "tts_models/multilingual/multi-dataset/xtts_v2/",
         "voice": default_engine_settings[TTS_ENGINES['XTTS']]['voice'],
         "files": default_engine_settings[TTS_ENGINES['XTTS']]['files'],
         "samplerate": default_engine_settings[TTS_ENGINES['XTTS']]['samplerate']
     },
-    "VietXTTS": {
-        "lang": "vie",
-        "repo": "drewThomasson/fineTunedTTSModels",
-        "sub": "Viet-xtts-v2/",
-        "voice": None,
-        "voice_sub": "Viet-xtts-v2/samples/vi_sample.wav",
-        "extra_languages": ("vi",),
-        "files": default_engine_settings[TTS_ENGINES['XTTS']]['files'],
-        "samplerate": default_engine_settings[TTS_ENGINES['XTTS']]['samplerate']
+    'VietXTTS': {
+        'lang': 'vie',
+        'repo': 'drewThomasson/fineTunedTTSModels',
+        'sub': 'Viet-xtts-v2/',
+        'voice': None,
+        'voice_sub': 'Viet-xtts-v2/samples/vi_sample.wav',
+        'extra_languages': ('vi',),
+        'files': default_engine_settings[TTS_ENGINES['XTTS']]['files'],
+        'samplerate': default_engine_settings[TTS_ENGINES['XTTS']]['samplerate']
     },
     "AiExplained": {
         "lang": "eng",

--- a/lib/classes/tts_engines/presets/xtts_presets.py
+++ b/lib/classes/tts_engines/presets/xtts_presets.py
@@ -5,6 +5,7 @@ from lib.conf_models import TTS_ENGINES, default_engine_settings
 models = {
     "internal": {
         "lang": "multi",
+        "exclude_langs": ("vie",),
         "repo": "coqui/XTTS-v2",
         "sub": "tts_models/multilingual/multi-dataset/xtts_v2/",
         "voice": default_engine_settings[TTS_ENGINES['XTTS']]['voice'],
@@ -17,6 +18,7 @@ models = {
         "sub": "Viet-xtts-v2/",
         "voice": None,
         "voice_sub": "Viet-xtts-v2/samples/vi_sample.wav",
+        "extra_languages": ("vi",),
         "files": default_engine_settings[TTS_ENGINES['XTTS']]['files'],
         "samplerate": default_engine_settings[TTS_ENGINES['XTTS']]['samplerate']
     },

--- a/lib/classes/tts_engines/xtts.py
+++ b/lib/classes/tts_engines/xtts.py
@@ -99,6 +99,12 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
                         config_path = hf_hub_download(repo_id=hf_repo, filename=f'{hf_sub}{self.models[self.session["fine_tuned"]]["files"][0]}', cache_dir=self.cache_dir)
                         checkpoint_path = hf_hub_download(repo_id=hf_repo, filename=f'{hf_sub}{self.models[self.session["fine_tuned"]]["files"][1]}', cache_dir=self.cache_dir)
                         vocab_path = hf_hub_download(repo_id=hf_repo, filename=f'{hf_sub}{self.models[self.session["fine_tuned"]]["files"][2]}', cache_dir=self.cache_dir)
+                        voice_sub = self.models[self.session['fine_tuned']].get('voice_sub')
+                        if voice_sub:
+                            preset_voice = hf_hub_download(repo_id=hf_repo, filename=voice_sub, cache_dir=self.cache_dir)
+                            self.models[self.session['fine_tuned']]['voice'] = preset_voice
+                            if self.session.get('voice') is None:
+                                self.session['voice'] = preset_voice
                         engine = self._load_checkpoint(tts_engine=self.session['tts_engine'], key=self.tts_key, checkpoint_path=checkpoint_path, config_path=config_path, vocab_path=vocab_path, device=self.device)
                     except Exception as e:
                         error = f'load_engine(): HuggingFace checkpoint loading failed: {e}'

--- a/lib/classes/tts_engines/xtts.py
+++ b/lib/classes/tts_engines/xtts.py
@@ -132,6 +132,9 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
         if 'vi' not in extra_languages:
             return
         tokenizer = engine.tokenizer
+        enabled_languages = getattr(tokenizer, '_e2a_extra_languages', set())
+        if 'vi' in enabled_languages:
+            return
         tokenizer.char_limits['vi'] = 250
         original_preprocess = tokenizer.preprocess_text
 
@@ -142,6 +145,7 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
             return original_preprocess(text, language)
 
         tokenizer.preprocess_text = MethodType(preprocess_text, tokenizer)
+        tokenizer._e2a_extra_languages = enabled_languages | {'vi'}
 
     def convert(self, sentence_file:str, sentence:str, **kwargs)->tuple:
         try:

--- a/lib/classes/tts_engines/xtts.py
+++ b/lib/classes/tts_engines/xtts.py
@@ -1,5 +1,6 @@
 from lib.classes.tts_engines.common.headers import *
-from lib.classes.tts_engines.common.preset_loader import load_engine_presets
+from lib.classes.tts_engines.common.preset_loader import get_compatible_presets, load_engine_presets
+from types import MethodType
 
 #sys.stderr = StdoutFilter(sys.stdout)
 
@@ -11,13 +12,17 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
             self.cache_dir = tts_dir
             self.speakers_path = None
             self.speaker = None
-            self.tts_key = self.session['model_cache']
             self.tts_zs_key = default_vc_model.rsplit('/',1)[-1]
             self.pth_voice_file = None
             self.resampler_cache = {}
             self.resampled_wav_cache = {}
             self.audio_segments = []
             self.models = load_engine_presets(self.session['tts_engine'])
+            compatible_presets = get_compatible_presets(self.models, self.session.get('language'))
+            if self.session.get('fine_tuned') not in compatible_presets and compatible_presets:
+                self.session['fine_tuned'] = compatible_presets[0]
+            self.tts_key = f"{self.session['tts_engine']}-{self.session['fine_tuned']}"
+            self.session['model_cache'] = self.tts_key
             self.params = {"latent_embedding":{}}
             # effective language for TTS (target when translating, else source)
             self.language = self.session.get('language')
@@ -103,13 +108,16 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
                         if voice_sub:
                             preset_voice = hf_hub_download(repo_id=hf_repo, filename=voice_sub, cache_dir=self.cache_dir)
                             self.models[self.session['fine_tuned']]['voice'] = preset_voice
-                            if self.session.get('voice') is None:
+                            current_voice = self.session.get('voice')
+                            current_speaker = Path(current_voice).stem if isinstance(current_voice, str) else None
+                            if current_voice is None or current_speaker in default_engine_settings[TTS_ENGINES['XTTS']]['voices']:
                                 self.session['voice'] = preset_voice
                         engine = self._load_checkpoint(tts_engine=self.session['tts_engine'], key=self.tts_key, checkpoint_path=checkpoint_path, config_path=config_path, vocab_path=vocab_path, device=self.device)
                     except Exception as e:
                         error = f'load_engine(): HuggingFace checkpoint loading failed: {e}'
                         raise RuntimeError(error) from e
             if engine:
+                self._enable_extra_languages(engine, self.models[self.session['fine_tuned']])
                 msg = f'TTS {self.tts_key} Loaded!'
                 print(msg)
                 return engine
@@ -118,6 +126,22 @@ class XTTS(TTSUtils, TTSRegistry, name='xtts'):
         except Exception as e:
             error = f'load_engine() error: {e}'
             raise RuntimeError(error) from e
+
+    def _enable_extra_languages(self, engine:Any, model_cfg:dict)->None:
+        extra_languages = model_cfg.get('extra_languages', ())
+        if 'vi' not in extra_languages:
+            return
+        tokenizer = engine.tokenizer
+        tokenizer.char_limits['vi'] = 250
+        original_preprocess = tokenizer.preprocess_text
+
+        def preprocess_text(tokenizer_self, text:str, language:str)->str:
+            language = language.split('-')[0]
+            if language == 'vi':
+                return ' '.join(text.lower().split())
+            return original_preprocess(text, language)
+
+        tokenizer.preprocess_text = MethodType(preprocess_text, tokenizer)
 
     def convert(self, sentence_file:str, sentence:str, **kwargs)->tuple:
         try:

--- a/lib/conf_models.py
+++ b/lib/conf_models.py
@@ -75,7 +75,7 @@ max_custom_voices = 1000
 default_engine_settings = {
     TTS_ENGINES['XTTS']: {
         "repo": "coqui/XTTS-v2",
-        "languages": {"ara": "ar", "ces": "cs", "deu": "de", "eng": "en", "fra": "fr", "hin": "hi", "hun": "hu", "ita": "it", "jpn": "ja", "kor": "ko", "nld": "nl", "pol": "pl", "por": "pt", "rus": "ru", "spa": "es", "tur": "tr", "zho": "zh-cn"},
+        "languages": {"ara": "ar", "ces": "cs", "deu": "de", "eng": "en", "fra": "fr", "hin": "hi", "hun": "hu", "ita": "it", "jpn": "ja", "kor": "ko", "nld": "nl", "pol": "pl", "por": "pt", "rus": "ru", "spa": "es", "tur": "tr", "vie": "vi", "zho": "zh-cn"},
         "samplerate": 24000,
         "temperature": 0.75,
         #"codec_temperature": 0.3,

--- a/lib/gradio.py
+++ b/lib/gradio.py
@@ -1,7 +1,7 @@
 from lib.core import *
 
 def build_interface(args:dict)->gr.Blocks:
-    from lib.classes.tts_engines.common.preset_loader import load_engine_presets
+    from lib.classes.tts_engines.common.preset_loader import get_compatible_presets, load_engine_presets
     try:
         script_mode = args['script_mode']
         is_gui_process = args['is_gui_process']
@@ -1986,15 +1986,11 @@ def build_interface(args:dict)->gr.Blocks:
                     session = context.get_session(session_id)
                     if session and session.get('id', False):
                         models = load_engine_presets(session['tts_engine'])
-                        fine_tuned_options = [
-                            name
-                            for name, details in models.items()
-                            if details.get("lang") in ("multi", session['language'])
-                        ]
+                        fine_tuned_options = get_compatible_presets(models, session['language'])
                         if session['fine_tuned'] in fine_tuned_options:
                             fine_tuned = session['fine_tuned']
                         else:
-                            fine_tuned = default_fine_tuned
+                            fine_tuned = fine_tuned_options[0] if fine_tuned_options else default_fine_tuned
                         session['fine_tuned'] = fine_tuned
                         return gr.update(choices=fine_tuned_options, value=session['fine_tuned'])
                 except Exception as e:


### PR DESCRIPTION
## Summary

- enable XTTS as an engine choice for Vietnamese (`vie` -> `vi`)
- add a `VietXTTS` fine-tuned preset backed by `drewThomasson/fineTunedTTSModels/Viet-xtts-v2`
- automatically select `VietXTTS` for Vietnamese because stock XTTS does not implement `vi` preprocessing
- add the Vietnamese tokenizer preprocessing used by the upstream VietXTTS fork, scoped only to presets declaring `vi` support
- lazily download the model's existing `samples/vi_sample.wav` as the default conditioning reference
- preserve user-supplied voice references when one is selected

## Validation

- `python3 -m py_compile` passed for all modified Python modules
- `git diff --check` passed
- verified the referenced Hugging Face repository contains `config.json`, `model.pth`, `vocab.json`, and `samples/vi_sample.wav`
- completed an end-to-end MPS run with Vietnamese input without specifying `--fine_tuned`; E2A loaded `xtts-VietXTTS`, synthesized the chapter, and exported a valid M4B and VTT

## Why the tokenizer adapter is required

The model adds Vietnamese tokens to its vocabulary, but the standard Coqui XTTS tokenizer rejects `vi` before tokenization. VietXTTS's fork handles Vietnamese by lowercasing and collapsing whitespace, then encoding with `[vi]`. This PR applies that behavior only to compatible fine-tuned presets.